### PR TITLE
Use regex to replace variables like %u and %USERPROFILE%.

### DIFF
--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -269,6 +269,7 @@ Module LaunchDotDesktop
                         ' Done figuring out the desktop entry type.
                     End If
 
+                    urlList = regexReplaceFlags(urlList, "%userprofile%", "C:\Users\drewn\")
                     ' Now, see if urlList has anything in it, and if it does,
                     ' send that URL as an argument to the application.
                     Dim execProgram As New ProcessStartInfo
@@ -355,7 +356,16 @@ Module LaunchDotDesktop
         ' \b is for the word border at the end.
         ' This can't be used with flags/environment variables
         ' that end with a percent sign.
-        Dim regexThing As New Regex("\s+" & flag & "\b")
+
+        Dim tempRegex As String = ""
+        If flag.EndsWith("%") Then
+            tempRegex = "\s+" & flag.TrimEnd(CType("%", Char())) & "\b%"
+        Else
+            tempRegex = "\s+" & flag & "\b"
+        End If
+
+        Dim regexThing As New Regex(tempRegex)
+
         ' Now we perform the replacement.
         Return regexThing.Replace(input, desiredReplacement)
     End Function
@@ -367,7 +377,11 @@ Module LaunchDotDesktop
         ' \b is for the word border at the end.
         ' This can't be used with flags/environment variables
         ' that end with a percent sign.
-        Return Regex.IsMatch(input, "\s+" & flag & "\b")
+        Dim percent As String = ""
+        If flag.EndsWith("%") Then
+            percent = "%"
+        End If
+        Return Regex.IsMatch(input, "\s+" & flag & "\b" & percent)
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -95,12 +95,15 @@ Module LaunchDotDesktop
                             urlList = InputBox("Please type or paste a URL:", "Single URL input")
                             ' Expand %u to what the user entered.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+
 
                         ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
                             ' If there's a %U in the file, open a window to allow for entering URLs.
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
 
                         ElseIf cleanedExecKey.Contains(" %f") Then
                             ' If there's a %f, allow for choosing one file.

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -146,18 +146,6 @@ Module LaunchDotDesktop
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-
-                                ' TODO: Remove any instances of %u, %U, and %F
-                                ' after merging back into master.
-                                ' Actually, this will probably require using Regex.
-                                ' The developer of WinYourDesktop appears to have done
-                                ' the same thing where they used Regex to replace variables,
-                                ' and it looks like a good way to do this to make sure the correct
-                                ' variables are replaced.
-                                ' Maybe what should be done is to have this code
-                                ' in a function so that it's reusable, kinda like what's done in WinYourDesktop.
-                                ' This tutorial on Regex in VB.Net looks pretty good:
-                                ' https://www.tutorialspoint.com/vb.net/vb.net_regular_expressions.htm
                             End If
 
                         ElseIf regexCheckFlags(cleanedExecKey, "%F") Then

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -90,17 +90,16 @@ Module LaunchDotDesktop
 
                         ' Determine if the application allows for entering a URL,
                         ' and provide a space to type it in.
-                        If cleanedExecKey.Contains(" %u") Then
+                        If regexCheckFlags(cleanedExecKey, "%u") Then
                             ' If there's a %u in the file, open a window to ask for a URL.
                             urlList = InputBox("Please type or paste a URL:", "Single URL input")
                             ' Expand %u to what the user entered.
-                            cleanedExecKey = cleanedExecKey.Replace(" %u", " " & urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", urlList)
 
                         ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
                             ' If there's a %U in the file, open a window to allow for entering URLs.
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
-                            'cleanedExecKey = cleanedExecKey.Replace(" %U", " " & urlList)
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", urlList)
 
                         ElseIf cleanedExecKey.Contains(" %f") Then

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -269,7 +269,10 @@ Module LaunchDotDesktop
                         ' Done figuring out the desktop entry type.
                     End If
 
-                    urlList = regexReplaceFlags(urlList, "%userprofile%", "C:\Users\drewn\", False)
+                    If regexCheckFlags(urlList, "%userprofile%", False) Then
+                        urlList = regexReplaceFlags(urlList, "%userprofile%", "C:\Users\drewn\", False)
+                    End If
+
                     ' Now, see if urlList has anything in it, and if it does,
                     ' send that URL as an argument to the application.
                     Dim execProgram As New ProcessStartInfo
@@ -383,7 +386,7 @@ Module LaunchDotDesktop
         End If
     End Function
 
-    Private Function regexCheckFlags(input As String, flag As String) As Boolean
+    Private Function regexCheckFlags(input As String, flag As String, Optional caseSensitive As Boolean = True) As Boolean
         ' Check to see if the input string contains a flag in the style of %u using regex.
         ' If there's a match, this'll return a Boolean.
         ' \s+ is for whitespace before the flag.
@@ -396,7 +399,12 @@ Module LaunchDotDesktop
             tempRegex = "\s+" & flag.TrimEnd(CType("%", Char())) & "\b%"
         End If
 
-        Return Regex.IsMatch(input, tempRegex)
+        If caseSensitive = False Then
+            Return Regex.IsMatch(input, tempRegex, RegexOptions.IgnoreCase)
+        Else
+            Return Regex.IsMatch(input, tempRegex)
+        End If
+
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -97,6 +97,8 @@ Module LaunchDotDesktop
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
                             ' Clean up unused flags.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
 
 
                         ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
@@ -133,6 +135,10 @@ Module LaunchDotDesktop
                                 ' Update cleanedExecKey with the fileName, which may or may not have been modified
                                 ' to be Linux-style if the desktop entry file wanted it or not.
                                 cleanedExecKey = cleanedExecKey.Replace(" %f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
                             Else
                                 ' If the user cancels, just remove the %f.
                                 cleanedExecKey = cleanedExecKey.Replace(" %f", "")
@@ -209,9 +215,17 @@ Module LaunchDotDesktop
                                 ' of the file list after putting in a space to separate it from the rest
                                 ' of the command.
                                 cleanedExecKey = cleanedExecKey.Replace(" %F", " " & filesList)
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
                             Else
                                 ' If the user cancels, just remove the %F.
                                 cleanedExecKey = cleanedExecKey.Replace(" %F", "")
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
                             End If
                         End If
 

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -269,10 +269,6 @@ Module LaunchDotDesktop
                         ' Done figuring out the desktop entry type.
                     End If
 
-                    If regexCheckFlags(urlList, "%userprofile%", False) Then
-                        urlList = regexReplaceFlags(urlList, "%userprofile%", "C:\Users\drewn\", False)
-                    End If
-
                     ' Now, see if urlList has anything in it, and if it does,
                     ' send that URL as an argument to the application.
                     Dim execProgram As New ProcessStartInfo

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -86,21 +86,22 @@ Module LaunchDotDesktop
                         ' %v is deprecated.
                         cleanedExecKey = cleanedExecKey.Replace(" %v", "")
                         ' %m is deprecated.
-                        cleanedExecKey = cleanedExecKey.Replace(" %m", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "m", "")
+                        MessageBox.Show(cleanedExecKey)
 
                         ' Determine if the application allows for entering a URL,
                         ' and provide a space to type it in.
-                        If regexCheckFlags(cleanedExecKey, "%u") Then
+                        If regexCheckFlags(cleanedExecKey, "u") Then
                             ' If there's a %u in the file, open a window to ask for a URL.
                             urlList = InputBox("Please type or paste a URL:", "Single URL input")
                             ' Expand %u to what the user entered.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "u", urlList)
 
-                        ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
+                        ElseIf regexCheckFlags(cleanedExecKey, "U") Then
                             ' If there's a %U in the file, open a window to allow for entering URLs.
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "U", urlList)
 
                         ElseIf cleanedExecKey.Contains(" %f") Then
                             ' If there's a %f, allow for choosing one file.
@@ -334,13 +335,13 @@ Module LaunchDotDesktop
 
     'End Function
 
-    Private Function regexReplaceFlags(input As String, flag As String, desiredPath As String) As String
-        Dim regexThing As New Regex("\" & flag & "$")
-        Return regexThing.Replace(input.TrimEnd, desiredPath)
+    Private Function regexReplaceFlags(input As String, flag As String, desiredReplacement As String) As String
+        Dim regexThing As New Regex("%" & flag & "\b")
+        Return regexThing.Replace(input, desiredReplacement)
     End Function
 
     Private Function regexCheckFlags(input As String, flag As String) As Boolean
-        Return Regex.IsMatch(input.TrimEnd, "\s\" & flag & "$")
+        Return Regex.IsMatch(input, "\s%" & flag & "\b")
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -269,7 +269,7 @@ Module LaunchDotDesktop
                         ' Done figuring out the desktop entry type.
                     End If
 
-                    urlList = regexReplaceFlags(urlList, "%userprofile%", "C:\Users\drewn\")
+                    urlList = regexReplaceFlags(urlList, "%userprofile%", "C:\Users\drewn\", False)
                     ' Now, see if urlList has anything in it, and if it does,
                     ' send that URL as an argument to the application.
                     Dim execProgram As New ProcessStartInfo
@@ -348,16 +348,15 @@ Module LaunchDotDesktop
         Return fileName
     End Function
 
-    Private Function regexReplaceFlags(input As String, flag As String, desiredReplacement As String) As String
+    Private Function regexReplaceFlags(input As String, flag As String, desiredReplacement As String, Optional caseSensitive As Boolean = True) As String
         ' Replaces flags in the style of %u with a string using regex.
         ' First we need to create a regular expression to match what'll
         ' be replaced.
         ' \s+ is for whitespace before the flag.
         ' \b is for the word border at the end.
         ' This can be used with flags/environment variables
-        ' that end with a percent sign, though case sensitivity
-        ' is still enforced for now and it needs to be allowed
-        ' to be turned off.
+        ' that end with a percent sign.
+        ' The case-sensitive if statement may need to be cleaned up a bit.
 
         Dim tempRegex As String = "\s+" & flag & "\b"
 
@@ -365,10 +364,15 @@ Module LaunchDotDesktop
             tempRegex = "\s+" & flag.TrimEnd(CType("%", Char())) & "\b%"
         End If
 
-        Dim regexThing As New Regex(tempRegex)
-
-        ' Now we perform the replacement.
-        Return regexThing.Replace(input, desiredReplacement)
+        If caseSensitive = False Then
+            Dim regexThing As New Regex(tempRegex, RegexOptions.IgnoreCase)
+            ' Now we perform the replacement.
+            Return regexThing.Replace(input, desiredReplacement)
+        Else
+            Dim regexThing As New Regex(tempRegex)
+            ' Now we perform the replacement.
+            Return regexThing.Replace(input, desiredReplacement)
+        End If
     End Function
 
     Private Function regexCheckFlags(input As String, flag As String) As Boolean

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -336,12 +336,12 @@ Module LaunchDotDesktop
     'End Function
 
     Private Function regexReplaceFlags(input As String, flag As String, desiredPath As String) As String
-        Dim regexThing As New Regex("\" & flag & "\s*")
+        Dim regexThing As New Regex("\" & flag & "$")
         Return regexThing.Replace(input, desiredPath)
     End Function
 
     Private Function regexCheckFlags(input As String, flag As String) As Boolean
-        Return Regex.IsMatch(input, "\s\" & flag & "\s*")
+        Return Regex.IsMatch(input, "\s\" & flag & "$")
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -337,11 +337,11 @@ Module LaunchDotDesktop
 
     Private Function regexReplaceFlags(input As String, flag As String, desiredPath As String) As String
         Dim regexThing As New Regex("\" & flag & "$")
-        Return regexThing.Replace(input, desiredPath)
+        Return regexThing.Replace(input.TrimEnd, desiredPath)
     End Function
 
     Private Function regexCheckFlags(input As String, flag As String) As Boolean
-        Return Regex.IsMatch(input, "\s\" & flag & "$")
+        Return Regex.IsMatch(input.TrimEnd, "\s\" & flag & "$")
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -101,7 +101,7 @@ Module LaunchDotDesktop
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
                             'cleanedExecKey = cleanedExecKey.Replace(" %U", " " & urlList)
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "\%U\s", urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", urlList)
 
                         ElseIf cleanedExecKey.Contains(" %f") Then
                             ' If there's a %f, allow for choosing one file.
@@ -336,12 +336,12 @@ Module LaunchDotDesktop
     'End Function
 
     Private Function regexReplaceFlags(input As String, flag As String, desiredPath As String) As String
-        Dim regexThing As New Regex(flag)
+        Dim regexThing As New Regex("\" & flag & "\s*")
         Return regexThing.Replace(input, desiredPath)
     End Function
 
     Private Function regexCheckFlags(input As String, flag As String) As Boolean
-        Return Regex.IsMatch(input, "\s\" & flag & "\s+")
+        Return Regex.IsMatch(input, "\s\" & flag & "\s*")
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -141,7 +141,7 @@ Module LaunchDotDesktop
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
                             Else
                                 ' If the user cancels, just remove the %f.
-                                cleanedExecKey = cleanedExecKey.Replace(" %f", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
                                 ' Clean up unused flags.
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -391,17 +391,27 @@ Module LaunchDotDesktop
         ' If there's a match, this'll return a Boolean.
         ' \s+ is for whitespace before the flag.
         ' \b is for the word border at the end.
-        ' This can't be used with flags/environment variables
+        ' This can be used with flags/environment variables
         ' that end with a percent sign.
+
+        ' Create temporary string for regex pattern.
         Dim tempRegex As String = "\s+" & flag & "\b"
 
         If flag.EndsWith("%") Then
+            ' If the flag ends with a percent sign,
+            ' change the regex string to work with it.
             tempRegex = "\s+" & flag.TrimEnd(CType("%", Char())) & "\b%"
         End If
 
         If caseSensitive = False Then
+            ' If case sensitivity isn't desired for this
+            ' flag (such as for %userprofile%), have
+            ' the regex thing ignore case when returning
+            ' the boolean.
             Return Regex.IsMatch(input, tempRegex, RegexOptions.IgnoreCase)
         Else
+            ' Otherwise, case sensitivity is necessary, so
+            ' it'll be used.
             Return Regex.IsMatch(input, tempRegex)
         End If
 

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -376,11 +376,13 @@ Module LaunchDotDesktop
         ' \b is for the word border at the end.
         ' This can't be used with flags/environment variables
         ' that end with a percent sign.
-        Dim percent As String = ""
+        Dim tempRegex As String = "\s+" & flag & "\b"
+
         If flag.EndsWith("%") Then
-            percent = "%"
+            tempRegex = "\s+" & flag.TrimEnd(CType("%", Char())) & "\b%"
         End If
-        Return Regex.IsMatch(input, "\s+" & flag & "\b" & percent)
+
+        Return Regex.IsMatch(input, tempRegex)
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -354,8 +354,10 @@ Module LaunchDotDesktop
         ' be replaced.
         ' \s+ is for whitespace before the flag.
         ' \b is for the word border at the end.
-        ' This can't be used with flags/environment variables
-        ' that end with a percent sign.
+        ' This can be used with flags/environment variables
+        ' that end with a percent sign, though case sensitivity
+        ' is still enforced for now and it needs to be allowed
+        ' to be turned off.
 
         Dim tempRegex As String = "\s+" & flag & "\b"
 

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -357,11 +357,10 @@ Module LaunchDotDesktop
         ' This can't be used with flags/environment variables
         ' that end with a percent sign.
 
-        Dim tempRegex As String = ""
+        Dim tempRegex As String = "\s+" & flag & "\b"
+
         If flag.EndsWith("%") Then
             tempRegex = "\s+" & flag.TrimEnd(CType("%", Char())) & "\b%"
-        Else
-            tempRegex = "\s+" & flag & "\b"
         End If
 
         Dim regexThing As New Regex(tempRegex)

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -218,7 +218,7 @@ Module LaunchDotDesktop
                                 ' Expand %F with the new file list, and add double-quotes on each side
                                 ' of the file list after putting in a space to separate it from the rest
                                 ' of the command.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList)
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList.TrimEnd)
                                 ' Clean up unused flags.
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -142,6 +142,10 @@ Module LaunchDotDesktop
                             Else
                                 ' If the user cancels, just remove the %f.
                                 cleanedExecKey = cleanedExecKey.Replace(" %f", "")
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
 
                                 ' TODO: Remove any instances of %u, %U, and %F
                                 ' after merging back into master.

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -76,31 +76,31 @@ Module LaunchDotDesktop
 #Region "Clean up Exec key if needed, and allow for choosing files and URLs."
 
                         ' %d is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "d", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%d", "")
                         ' %D is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "D", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%D", "")
                         ' %n is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "n", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%n", "")
                         ' %N is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "N", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%N", "")
                         ' %v is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "v", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%v", "")
                         ' %m is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "m", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%m", "")
 
                         ' Determine if the application allows for entering a URL,
                         ' and provide a space to type it in.
-                        If regexCheckFlags(cleanedExecKey, "u") Then
+                        If regexCheckFlags(cleanedExecKey, "%u") Then
                             ' If there's a %u in the file, open a window to ask for a URL.
                             urlList = InputBox("Please type or paste a URL:", "Single URL input")
                             ' Expand %u to what the user entered.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "u", urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
 
-                        ElseIf regexCheckFlags(cleanedExecKey, "U") Then
+                        ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
                             ' If there's a %U in the file, open a window to allow for entering URLs.
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "U", urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
 
                         ElseIf cleanedExecKey.Contains(" %f") Then
                             ' If there's a %f, allow for choosing one file.
@@ -335,12 +335,12 @@ Module LaunchDotDesktop
     'End Function
 
     Private Function regexReplaceFlags(input As String, flag As String, desiredReplacement As String) As String
-        Dim regexThing As New Regex("%" & flag & "\b")
+        Dim regexThing As New Regex("\s" & flag & "\b")
         Return regexThing.Replace(input, desiredReplacement)
     End Function
 
     Private Function regexCheckFlags(input As String, flag As String) As Boolean
-        Return Regex.IsMatch(input, "\s%" & flag & "\b")
+        Return Regex.IsMatch(input, "\s" & flag & "\b")
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -95,6 +95,7 @@ Module LaunchDotDesktop
                             urlList = InputBox("Please type or paste a URL:", "Single URL input")
                             ' Expand %u to what the user entered.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
+                            ' Clean up unused flags.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
 
 
@@ -103,6 +104,7 @@ Module LaunchDotDesktop
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
+                            ' Clean up unused flags.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
 
                         ElseIf cleanedExecKey.Contains(" %f") Then
@@ -327,23 +329,27 @@ Module LaunchDotDesktop
         Return fileName
     End Function
 
-    'Private Function regexReplacer(inputText As String, regexExpression As String)
-    '    Dim matchList As MatchCollection = Regex.Matches(inputText, regexExpression)
-    '    Dim match As Match
-
-    '    For Each match In matchList
-    '        If match Then
-    '    Next
-
-    'End Function
-
     Private Function regexReplaceFlags(input As String, flag As String, desiredReplacement As String) As String
-        Dim regexThing As New Regex("\s" & flag & "\b")
+        ' Replaces flags in the style of %u with a string using regex.
+        ' First we need to create a regular expression to match what'll
+        ' be replaced.
+        ' \s+ is for whitespace before the flag.
+        ' \b is for the word border at the end.
+        ' This can't be used with flags/environment variables
+        ' that end with a percent sign.
+        Dim regexThing As New Regex("\s+" & flag & "\b")
+        ' Now we perform the replacement.
         Return regexThing.Replace(input, desiredReplacement)
     End Function
 
     Private Function regexCheckFlags(input As String, flag As String) As Boolean
-        Return Regex.IsMatch(input, "\s" & flag & "\b")
+        ' Check to see if the input string contains a flag in the style of %u using regex.
+        ' If there's a match, this'll return a Boolean.
+        ' \s+ is for whitespace before the flag.
+        ' \b is for the word border at the end.
+        ' This can't be used with flags/environment variables
+        ' that end with a percent sign.
+        Return Regex.IsMatch(input, "\s+" & flag & "\b")
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -160,7 +160,7 @@ Module LaunchDotDesktop
                                 ' https://www.tutorialspoint.com/vb.net/vb.net_regular_expressions.htm
                             End If
 
-                        ElseIf cleanedExecKey.Contains(" %F") Then
+                        ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
                             ' If there's a %F, allow for choosing multiple files.
                             Dim openFileDialog As New OpenFileDialog()
                             openFileDialog.Filter = "All files (*.*)|*.*"
@@ -218,14 +218,14 @@ Module LaunchDotDesktop
                                 ' Expand %F with the new file list, and add double-quotes on each side
                                 ' of the file list after putting in a space to separate it from the rest
                                 ' of the command.
-                                cleanedExecKey = cleanedExecKey.Replace(" %F", " " & filesList)
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList)
                                 ' Clean up unused flags.
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
                             Else
                                 ' If the user cancels, just remove the %F.
-                                cleanedExecKey = cleanedExecKey.Replace(" %F", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
                                 ' Clean up unused flags.
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -109,7 +109,7 @@ Module LaunchDotDesktop
                             ' Clean up unused flags.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
 
-                        ElseIf cleanedExecKey.Contains(" %f") Then
+                        ElseIf regexCheckFlags(cleanedExecKey, "%f") Then
                             ' If there's a %f, allow for choosing one file.
                             Dim openFileDialog As New OpenFileDialog()
                             openFileDialog.Filter = "All files (*.*)|*.*"
@@ -134,7 +134,7 @@ Module LaunchDotDesktop
 
                                 ' Update cleanedExecKey with the fileName, which may or may not have been modified
                                 ' to be Linux-style if the desktop entry file wanted it or not.
-                                cleanedExecKey = cleanedExecKey.Replace(" %f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
                                 ' Clean up unused flags.
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
                                 cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -76,18 +76,17 @@ Module LaunchDotDesktop
 #Region "Clean up Exec key if needed, and allow for choosing files and URLs."
 
                         ' %d is deprecated.
-                        cleanedExecKey = cleanedExecKey.Replace(" %d", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "d", "")
                         ' %D is deprecated.
-                        cleanedExecKey = cleanedExecKey.Replace(" %D", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "D", "")
                         ' %n is deprecated.
-                        cleanedExecKey = cleanedExecKey.Replace(" %n", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "n", "")
                         ' %N is deprecated.
-                        cleanedExecKey = cleanedExecKey.Replace(" %N", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "N", "")
                         ' %v is deprecated.
-                        cleanedExecKey = cleanedExecKey.Replace(" %v", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "v", "")
                         ' %m is deprecated.
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "m", "")
-                        MessageBox.Show(cleanedExecKey)
 
                         ' Determine if the application allows for entering a URL,
                         ' and provide a space to type it in.

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -132,6 +132,15 @@ Module LaunchDotDesktop
 
                                 ' TODO: Remove any instances of %u, %U, and %F
                                 ' after merging back into master.
+                                ' Actually, this will probably require using Regex.
+                                ' The developer of WinYourDesktop appears to have done
+                                ' the same thing where they used Regex to replace variables,
+                                ' and it looks like a good way to do this to make sure the correct
+                                ' variables are replaced.
+                                ' Maybe what should be done is to have this code
+                                ' in a function so that it's reusable, kinda like what's done in WinYourDesktop.
+                                ' This tutorial on Regex in VB.Net looks pretty good:
+                                ' https://www.tutorialspoint.com/vb.net/vb.net_regular_expressions.htm
                             End If
 
                         ElseIf cleanedExecKey.Contains(" %F") Then
@@ -156,7 +165,7 @@ Module LaunchDotDesktop
                                 For Each fileName As String In fileNameList
                                     ' If the .desktop file requests it, switch the paths to be Linux-style.
                                     If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
-                                        
+
                                         ' Set quote used in file paths to a single quote.
                                         quoteForFilePaths = "'"
                                         ' Add the newly-modified filename to the path list.

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -96,7 +96,7 @@ Module LaunchDotDesktop
                             ' Expand %u to what the user entered.
                             cleanedExecKey = cleanedExecKey.Replace(" %u", " " & urlList)
 
-                        ElseIf Regex.IsMatch(cleanedExecKey, "\s\%U\s") Then
+                        ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
                             ' If there's a %U in the file, open a window to allow for entering URLs.
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
@@ -338,6 +338,10 @@ Module LaunchDotDesktop
     Private Function regexReplaceFlags(input As String, flag As String, desiredPath As String) As String
         Dim regexThing As New Regex(flag)
         Return regexThing.Replace(input, desiredPath)
+    End Function
+
+    Private Function regexCheckFlags(input As String, flag As String) As Boolean
+        Return Regex.IsMatch(input, "\s\" & flag & "\s+")
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -22,6 +22,8 @@
 
 Imports System.Windows.Forms
 Imports libdotdesktop
+Imports System.Text.RegularExpressions
+
 Module LaunchDotDesktop
 
     Public Sub Main()
@@ -94,11 +96,12 @@ Module LaunchDotDesktop
                             ' Expand %u to what the user entered.
                             cleanedExecKey = cleanedExecKey.Replace(" %u", " " & urlList)
 
-                        ElseIf cleanedExecKey.Contains(" %U") Then
+                        ElseIf Regex.IsMatch(cleanedExecKey, "\s\%U\s") Then
                             ' If there's a %U in the file, open a window to allow for entering URLs.
                             urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
                             ' Expand %U to what the user entered.
-                            cleanedExecKey = cleanedExecKey.Replace(" %U", " " & urlList)
+                            'cleanedExecKey = cleanedExecKey.Replace(" %U", " " & urlList)
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "\%U\s", urlList)
 
                         ElseIf cleanedExecKey.Contains(" %f") Then
                             ' If there's a %f, allow for choosing one file.
@@ -320,6 +323,21 @@ Module LaunchDotDesktop
         ' Remove the single quote on the end.
         fileName = fileName.TrimEnd(CType("'", Char()))
         Return fileName
+    End Function
+
+    'Private Function regexReplacer(inputText As String, regexExpression As String)
+    '    Dim matchList As MatchCollection = Regex.Matches(inputText, regexExpression)
+    '    Dim match As Match
+
+    '    For Each match In matchList
+    '        If match Then
+    '    Next
+
+    'End Function
+
+    Private Function regexReplaceFlags(input As String, flag As String, desiredPath As String) As String
+        Dim regexThing As New Regex(flag)
+        Return regexThing.Replace(input, desiredPath)
     End Function
 
 End Module

--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -358,17 +358,25 @@ Module LaunchDotDesktop
         ' that end with a percent sign.
         ' The case-sensitive if statement may need to be cleaned up a bit.
 
+        ' Create a temp string to hold the regex for now.
         Dim tempRegex As String = "\s+" & flag & "\b"
 
         If flag.EndsWith("%") Then
+            ' If the flag ends with a percent sign,
+            ' change the regex temp string to work
+            ' with it so it's matched later.
             tempRegex = "\s+" & flag.TrimEnd(CType("%", Char())) & "\b%"
         End If
 
         If caseSensitive = False Then
+            ' If case-insensitivity is fine for this
+            ' flag, have the regex thing ignore case.
             Dim regexThing As New Regex(tempRegex, RegexOptions.IgnoreCase)
             ' Now we perform the replacement.
             Return regexThing.Replace(input, desiredReplacement)
         Else
+            ' Otherwise, don't have the regex thing
+            ' ignore case.
             Dim regexThing As New Regex(tempRegex)
             ' Now we perform the replacement.
             Return regexThing.Replace(input, desiredReplacement)


### PR DESCRIPTION
Regex allows us to do things like making sure we don't accidentally expand the `%U` at the beginning of `%USERPROFILE%`, leaving something like `ddg.ggSERPROFILE%`.