### PR TITLE
Clean keys in the library.

### DIFF
--- a/LaunchDotDesktop/LaunchDotDesktopMain.vb
+++ b/LaunchDotDesktop/LaunchDotDesktopMain.vb
@@ -40,6 +40,7 @@ Module LaunchDotDesktop
                 desktopEntryStuff.checkHeader(My.Application.CommandLineArgs(0).ToString) = "KDE Desktop Entry" Then
 
                 ' First, update titlebar and output the file path.
+                ' Keep this output, as we need to have it in here.
                 Console.WriteLine()
                 Console.WriteLine("Input file: " & My.Application.CommandLineArgs(0).ToString)
                 Console.Title = System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -282,20 +282,12 @@ Public Class desktopEntryStuff
 #Region "Cleaning keys."
     ' This function will clean keys as passed to it.
     ' Some features are only available on Windows, such as the file browser dialog.
-    Public Shared Function cleanKey(inputFile As String) As String
+    Public Shared Function cleanExecKey(inputFile As String) As String
         ' Before doing anything, make sure this is a valid .desktop file
         ' with the proper Desktop Entry/KDE Desktop Entry header.
         If checkHeader(inputFile) = "Desktop Entry" OrElse checkHeader(inputFile) = "KDE Desktop Entry" Then
 
-            ' First, update titlebar and output the file path.
-            Console.WriteLine()
-            Console.WriteLine("Input file: " & My.Application.CommandLineArgs(0).ToString)
-            Console.Title = System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName
-
-            ' Second, update the console after replacing Lf with CrLf.
-            Console.WriteLine(System.IO.File.ReadAllText(My.Application.CommandLineArgs(0).ToString).Replace(vbLf, vbCrLf))
-
-            ' Now, pass along the file to the interpretation code in libdotdesktop.
+            ' Now, clean the exec key.
             ' Catch NullReferenceExceptions, just in case there are issues in the file.
             Try
                 ' Exec key.
@@ -549,7 +541,7 @@ Public Class desktopEntryStuff
             ' If it's not a valid Freedesktop.org .desktop file, tell the user.
             MessageBox.Show("This .desktop file doesn't have a valid Desktop Entry header/section, which is required by the Freedesktop.org Desktop Entry spec.",
                                 "Launch .desktop file")
-            End If
+        End If
     End Function
 #End Region
 

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -53,6 +53,7 @@ Public Class desktopEntryStuff
         End If
     End Function
 
+#Region "GetInfo function."
     Public Shared Function getInfo(inputFile As String, keyToGet As String, Optional fileName As String = "", Optional IsCustomKey As Boolean = False) As String
 
         ' Get the input file and put it in an INI file object for later use.
@@ -273,14 +274,17 @@ Public Class desktopEntryStuff
                 End Select
 
         End Select
-
+#End Region
     End Function
 #End Region
+
 
 #Region "Cleaning keys."
     ' This function will clean keys as passed to it.
     ' Some features are only available on Windows, such as the file browser dialog.
+    Public Shared Function cleanKey(inputFile As String) As String
 
+    End Function
 #End Region
 
 End Class

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -278,6 +278,8 @@ Public Class desktopEntryStuff
 #End Region
 
 #Region "Cleaning keys."
+    ' This function will clean keys as passed to it.
+    ' Some features are only available on Windows, such as the file browser dialog.
 
 #End Region
 

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -366,7 +366,7 @@ Public Class desktopEntryStuff
                             Dim fileName As String = openFileDialog.FileName
                             Dim quoteForFilePaths As String = Chr(34)
                             ' If the .desktop file requests it, switch the paths to be Linux-style.
-                            If desktopEntryStuff.getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+                            If getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
 
                                 ' Convert the filename/file path to what WSL distros expect.
                                 fileName = convertPathsStyleToWSL(fileName)
@@ -415,7 +415,7 @@ Public Class desktopEntryStuff
                             Dim quoteForFilePaths As String = Chr(34)
                             For Each fileName As String In fileNameList
                                 ' If the .desktop file requests it, switch the paths to be Linux-style.
-                                If desktopEntryStuff.getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+                                If getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
 
                                     ' Set quote used in file paths to a single quote.
                                     quoteForFilePaths = "'"

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -273,8 +273,12 @@ Public Class desktopEntryStuff
                 End Select
 
         End Select
-#End Region
 
     End Function
+#End Region
+
+#Region "Cleaning keys."
+
+#End Region
 
 End Class

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -285,270 +285,269 @@ Public Class desktopEntryStuff
     Public Shared Function cleanKey(inputFile As String) As String
         ' Before doing anything, make sure this is a valid .desktop file
         ' with the proper Desktop Entry/KDE Desktop Entry header.
-        If desktopEntryStuff.checkHeader(My.Application.CommandLineArgs(0).ToString) = "Desktop Entry" Or
-                desktopEntryStuff.checkHeader(My.Application.CommandLineArgs(0).ToString) = "KDE Desktop Entry" Then
+        If checkHeader(inputFile) = "Desktop Entry" OrElse checkHeader(inputFile) = "KDE Desktop Entry" Then
 
-                ' First, update titlebar and output the file path.
-                Console.WriteLine()
-                Console.WriteLine("Input file: " & My.Application.CommandLineArgs(0).ToString)
-                Console.Title = System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName
+            ' First, update titlebar and output the file path.
+            Console.WriteLine()
+            Console.WriteLine("Input file: " & My.Application.CommandLineArgs(0).ToString)
+            Console.Title = System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName
 
-                ' Second, update the console after replacing Lf with CrLf.
-                Console.WriteLine(System.IO.File.ReadAllText(My.Application.CommandLineArgs(0).ToString).Replace(vbLf, vbCrLf))
+            ' Second, update the console after replacing Lf with CrLf.
+            Console.WriteLine(System.IO.File.ReadAllText(My.Application.CommandLineArgs(0).ToString).Replace(vbLf, vbCrLf))
 
-                ' Now, pass along the file to the interpretation code in libdotdesktop.
-                ' Catch NullReferenceExceptions, just in case there are issues in the file.
-                Try
-                    ' Exec key.
-                    Dim cleanedExecKey As String
-                    ' URL list for apps that allow for URLs to be passed to them.
-                    Dim urlList As String = ""
+            ' Now, pass along the file to the interpretation code in libdotdesktop.
+            ' Catch NullReferenceExceptions, just in case there are issues in the file.
+            Try
+                ' Exec key.
+                Dim cleanedExecKey As String
+                ' URL list for apps that allow for URLs to be passed to them.
+                Dim urlList As String = ""
 
-                    ' Check to see if the desktop entry is a link or an application.
-                    If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
+                ' Check to see if the desktop entry is a link or an application.
+                If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
                        desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL") IsNot Nothing Then
-                        ' If it's a link, grab the URL key if it exists.
-                        cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL")
+                    ' If it's a link, grab the URL key if it exists.
+                    cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL")
 
-                    ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
+                ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
                        desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL") Is Nothing Then
-                        ' If the URL key doesn't exist, allow for URL entry.
-                        cleanedExecKey = InputBox("Please type or paste a URL:", "URL key missing")
+                    ' If the URL key doesn't exist, allow for URL entry.
+                    cleanedExecKey = InputBox("Please type or paste a URL:", "URL key missing")
 
-                    ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Directory" Then
-                        ' Directories aren't supported in this program.
-                        MessageBox.Show("Directory entries aren't supported by LaunchDotDesktop.", "Unsupported entry type")
-                        Exit Try
-                    Else
-                        ' Otherwise, assume it's an application.
-                        cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Exec")
+                ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Directory" Then
+                    ' Directories aren't supported in this program.
+                    MessageBox.Show("Directory entries aren't supported by LaunchDotDesktop.", "Unsupported entry type")
+                    Exit Try
+                Else
+                    ' Otherwise, assume it's an application.
+                    cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Exec")
 #Region "Clean up Exec key if needed, and allow for choosing files and URLs."
 
-                        ' %d is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%d", "")
-                        ' %D is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%D", "")
-                        ' %n is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%n", "")
-                        ' %N is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%N", "")
-                        ' %v is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%v", "")
-                        ' %m is deprecated.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%m", "")
+                    ' %d is deprecated.
+                    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%d", "")
+                    ' %D is deprecated.
+                    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%D", "")
+                    ' %n is deprecated.
+                    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%n", "")
+                    ' %N is deprecated.
+                    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%N", "")
+                    ' %v is deprecated.
+                    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%v", "")
+                    ' %m is deprecated.
+                    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%m", "")
 
-                        ' Determine if the application allows for entering a URL,
-                        ' and provide a space to type it in.
-                        If regexCheckFlags(cleanedExecKey, "%u") Then
-                            ' If there's a %u in the file, open a window to ask for a URL.
-                            urlList = InputBox("Please type or paste a URL:", "Single URL input")
-                            ' Expand %u to what the user entered.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
-                            ' Clean up unused flags.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                    ' Determine if the application allows for entering a URL,
+                    ' and provide a space to type it in.
+                    If regexCheckFlags(cleanedExecKey, "%u") Then
+                        ' If there's a %u in the file, open a window to ask for a URL.
+                        urlList = InputBox("Please type or paste a URL:", "Single URL input")
+                        ' Expand %u to what the user entered.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
+                        ' Clean up unused flags.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
 
 
-                        ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
-                            ' If there's a %U in the file, open a window to allow for entering URLs.
-                            urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
-                            ' Expand %U to what the user entered.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
+                    ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
+                        ' If there's a %U in the file, open a window to allow for entering URLs.
+                        urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
+                        ' Expand %U to what the user entered.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
+                        ' Clean up unused flags.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+
+                    ElseIf regexCheckFlags(cleanedExecKey, "%f") Then
+                        ' If there's a %f, allow for choosing one file.
+                        Dim openFileDialog As New OpenFileDialog()
+                        openFileDialog.Filter = "All files (*.*)|*.*"
+                        openFileDialog.RestoreDirectory = True
+
+                        If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
+                            ' If the user chooses a file, replace %f with the filename and path.
+                            Dim fileName As String = openFileDialog.FileName
+                            Dim quoteForFilePaths As String = Chr(34)
+                            ' If the .desktop file requests it, switch the paths to be Linux-style.
+                            If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+
+                                ' Convert the filename/file path to what WSL distros expect.
+                                fileName = convertPathsStyleToWSL(fileName)
+                                ' Set quote used in file paths to a single quote.
+                                quoteForFilePaths = "'"
+
+                            Else
+                                ' Remove the double-quotes on the end of the filename.
+                                fileName = fileName.TrimEnd(Chr(34))
+                            End If
+
+                            ' Update cleanedExecKey with the fileName, which may or may not have been modified
+                            ' to be Linux-style if the desktop entry file wanted it or not.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
                             ' Clean up unused flags.
                             cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                        Else
+                            ' If the user cancels, just remove the %f.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                            ' Clean up unused flags.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                        End If
 
-                        ElseIf regexCheckFlags(cleanedExecKey, "%f") Then
-                            ' If there's a %f, allow for choosing one file.
-                            Dim openFileDialog As New OpenFileDialog()
-                            openFileDialog.Filter = "All files (*.*)|*.*"
-                            openFileDialog.RestoreDirectory = True
+                    ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
+                        ' If there's a %F, allow for choosing multiple files.
+                        Dim openFileDialog As New OpenFileDialog()
+                        openFileDialog.Filter = "All files (*.*)|*.*"
+                        openFileDialog.RestoreDirectory = True
+                        openFileDialog.Multiselect = True
 
-                            If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
-                                ' If the user chooses a file, replace %f with the filename and path.
-                                Dim fileName As String = openFileDialog.FileName
-                                Dim quoteForFilePaths As String = Chr(34)
+                        If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
+                            ' If the user chooses files, replace %F with the filename and paths.
+                            ' Get a file name list array as a string from the open file dialog.
+                            Dim fileNameList As String() = openFileDialog.FileNames
+
+                            ' Define a path list to store the filenames into.
+                            Dim entirePathList As New List(Of String)
+                            ' Define a quote character for putting at the beginning
+                            ' and end of filenames. This can be changed if necessary,
+                            ' such as if a desktop entry file wants to use a Linux-style
+                            ' path instead of Windows-style.
+                            Dim quoteForFilePaths As String = Chr(34)
+                            For Each fileName As String In fileNameList
                                 ' If the .desktop file requests it, switch the paths to be Linux-style.
                                 If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
 
-                                    ' Convert the filename/file path to what WSL distros expect.
-                                    fileName = convertPathsStyleToWSL(fileName)
                                     ' Set quote used in file paths to a single quote.
                                     quoteForFilePaths = "'"
+                                    ' Add the newly-modified filename to the path list.
+
+                                    ' Put a question mark at the end of the filename
+                                    ' for later use when joining the string.
+                                    ' It may be a good idea to allow this to be a configurable option
+                                    ' in case the user runs into issues on other filesystems that allow
+                                    ' the question mark to be in a filename.
+
+                                    ' Convert the filename/file path to what WSL distros expect.
+                                    entirePathList.Add(quoteForFilePaths & convertPathsStyleToWSL(fileName) & quoteForFilePaths & " ?")
 
                                 Else
                                     ' Remove the double-quotes on the end of the filename.
                                     fileName = fileName.TrimEnd(Chr(34))
+                                    ' Add the filename to the path list.
+
+                                    ' Put a question mark at the end of the filename
+                                    ' for later use when joining the string.
+                                    ' It may be a good idea to allow this to be a configurable option
+                                    ' in case the user runs into issues on other filesystems that allow
+                                    ' the question mark to be in a filename.
+                                    entirePathList.Add(quoteForFilePaths & fileName & quoteForFilePaths & " ?")
                                 End If
 
-                                ' Update cleanedExecKey with the fileName, which may or may not have been modified
-                                ' to be Linux-style if the desktop entry file wanted it or not.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
-                                ' Clean up unused flags.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                            Else
-                                ' If the user cancels, just remove the %f.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
-                                ' Clean up unused flags.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                            End If
+                            Next
+                            ' Make a new string that joins the file name list into one string.
+                            Dim filesList As String = String.Join("?", entirePathList)
+                            ' Replace the joiner character with an empty string.
+                            filesList = filesList.Replace("?", "")
 
-                        ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
-                            ' If there's a %F, allow for choosing multiple files.
-                            Dim openFileDialog As New OpenFileDialog()
-                            openFileDialog.Filter = "All files (*.*)|*.*"
-                            openFileDialog.RestoreDirectory = True
-                            openFileDialog.Multiselect = True
-
-                            If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
-                                ' If the user chooses files, replace %F with the filename and paths.
-                                ' Get a file name list array as a string from the open file dialog.
-                                Dim fileNameList As String() = openFileDialog.FileNames
-
-                                ' Define a path list to store the filenames into.
-                                Dim entirePathList As New List(Of String)
-                                ' Define a quote character for putting at the beginning
-                                ' and end of filenames. This can be changed if necessary,
-                                ' such as if a desktop entry file wants to use a Linux-style
-                                ' path instead of Windows-style.
-                                Dim quoteForFilePaths As String = Chr(34)
-                                For Each fileName As String In fileNameList
-                                    ' If the .desktop file requests it, switch the paths to be Linux-style.
-                                    If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
-
-                                        ' Set quote used in file paths to a single quote.
-                                        quoteForFilePaths = "'"
-                                        ' Add the newly-modified filename to the path list.
-
-                                        ' Put a question mark at the end of the filename
-                                        ' for later use when joining the string.
-                                        ' It may be a good idea to allow this to be a configurable option
-                                        ' in case the user runs into issues on other filesystems that allow
-                                        ' the question mark to be in a filename.
-
-                                        ' Convert the filename/file path to what WSL distros expect.
-                                        entirePathList.Add(quoteForFilePaths & convertPathsStyleToWSL(fileName) & quoteForFilePaths & " ?")
-
-                                    Else
-                                        ' Remove the double-quotes on the end of the filename.
-                                        fileName = fileName.TrimEnd(Chr(34))
-                                        ' Add the filename to the path list.
-
-                                        ' Put a question mark at the end of the filename
-                                        ' for later use when joining the string.
-                                        ' It may be a good idea to allow this to be a configurable option
-                                        ' in case the user runs into issues on other filesystems that allow
-                                        ' the question mark to be in a filename.
-                                        entirePathList.Add(quoteForFilePaths & fileName & quoteForFilePaths & " ?")
-                                    End If
-
-                                Next
-                                ' Make a new string that joins the file name list into one string.
-                                Dim filesList As String = String.Join("?", entirePathList)
-                                ' Replace the joiner character with an empty string.
-                                filesList = filesList.Replace("?", "")
-
-                                ' Expand %F with the new file list, and add double-quotes on each side
-                                ' of the file list after putting in a space to separate it from the rest
-                                ' of the command.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList.TrimEnd)
-                                ' Clean up unused flags.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
-                            Else
-                                ' If the user cancels, just remove the %F.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                                ' Clean up unused flags.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
-                            End If
-                        End If
-
-                        ' Split Exec key's program from the arguments, if necessary.
-                        ' Check to see if it starts with double-quotes.
-                        ' Get rid of whitespace on the left side.
-                        cleanedExecKey = LTrim(cleanedExecKey)
-
-                        ' Check for Chr(34), which is the double-quote character.
-                        If cleanedExecKey.StartsWith(Chr(34)) Then
-                            ' Copy the original cleaned exec key for later use in the arg variable.
-                            Dim originalCleanedExecKey As String = cleanedExecKey
-                            ' Create a temp key to be used when splitting out the EXE filename.
-                            Dim tempExecKey As String() = cleanedExecKey.Split(Chr(34))
-                            ' Trim the exec key out at the second double-quote.
-                            cleanedExecKey = tempExecKey(1).Trim
-                            ' Assign the arg variable to the copy of the exec key and remove
-                            ' the double-quotes before and after and the new exec key 
-                            ' from the beginning of the URL list/arg variable.
-                            urlList = originalCleanedExecKey.Remove(0, cleanedExecKey.Length + 2)
+                            ' Expand %F with the new file list, and add double-quotes on each side
+                            ' of the file list after putting in a space to separate it from the rest
+                            ' of the command.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList.TrimEnd)
+                            ' Clean up unused flags.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
                         Else
-                            ' If there's no double-quotes, assume it's something like
-                            ' firefox.exe or another string without spaces.
-                            ' We'll need to split this one at the first space character.
-
-                            ' Copy the original cleaned exec key for later use in the arg variable.
-                            Dim originalCleanedExecKey As String = cleanedExecKey
-                            ' Create a temp key to be used when splitting out the EXE filename.
-                            Dim tempExecKey As String() = cleanedExecKey.Split(" "c)
-                            ' Trim the exec key out at the first space.
-                            cleanedExecKey = tempExecKey(0).Trim
-                            ' Assign the arg variable to the copy of the exec key and trim
-                            ' out the exec key.
-                            urlList = originalCleanedExecKey.TrimStart(cleanedExecKey.ToCharArray)
+                            ' If the user cancels, just remove the %F.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                            ' Clean up unused flags.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
                         End If
-#End Region
-                        ' Done figuring out the desktop entry type.
                     End If
 
-                    ' Expand environment variables.
-                    cleanedExecKey = expandEnvVars(cleanedExecKey)
-                    If My.Settings.ShowExecKeyBeforeLaunch = True Then
-                        MessageBox.Show(cleanedExecKey)
-                    End If
-                    ' TODO: Switch the urlList to WSL paths if
-                    ' the .desktop file wants it.
-                    urlList = expandEnvVars(urlList)
+                    ' Split Exec key's program from the arguments, if necessary.
+                    ' Check to see if it starts with double-quotes.
+                    ' Get rid of whitespace on the left side.
+                    cleanedExecKey = LTrim(cleanedExecKey)
 
-                    ' Now, see if urlList has anything in it, and if it does,
-                    ' send that URL as an argument to the application.
-                    Dim execProgram As New ProcessStartInfo
-                    execProgram.FileName = cleanedExecKey
-                    execProgram.Arguments = urlList.Trim
-                    ' Don't add space if there are no args.
-                    If execProgram.Arguments.Length > 0 Then
-                        Console.WriteLine("Launching " & execProgram.FileName & " " & execProgram.Arguments & "...")
+                    ' Check for Chr(34), which is the double-quote character.
+                    If cleanedExecKey.StartsWith(Chr(34)) Then
+                        ' Copy the original cleaned exec key for later use in the arg variable.
+                        Dim originalCleanedExecKey As String = cleanedExecKey
+                        ' Create a temp key to be used when splitting out the EXE filename.
+                        Dim tempExecKey As String() = cleanedExecKey.Split(Chr(34))
+                        ' Trim the exec key out at the second double-quote.
+                        cleanedExecKey = tempExecKey(1).Trim
+                        ' Assign the arg variable to the copy of the exec key and remove
+                        ' the double-quotes before and after and the new exec key 
+                        ' from the beginning of the URL list/arg variable.
+                        urlList = originalCleanedExecKey.Remove(0, cleanedExecKey.Length + 2)
                     Else
-                        Console.WriteLine("Launching " & execProgram.FileName & "...")
+                        ' If there's no double-quotes, assume it's something like
+                        ' firefox.exe or another string without spaces.
+                        ' We'll need to split this one at the first space character.
+
+                        ' Copy the original cleaned exec key for later use in the arg variable.
+                        Dim originalCleanedExecKey As String = cleanedExecKey
+                        ' Create a temp key to be used when splitting out the EXE filename.
+                        Dim tempExecKey As String() = cleanedExecKey.Split(" "c)
+                        ' Trim the exec key out at the first space.
+                        cleanedExecKey = tempExecKey(0).Trim
+                        ' Assign the arg variable to the copy of the exec key and trim
+                        ' out the exec key.
+                        urlList = originalCleanedExecKey.TrimStart(cleanedExecKey.ToCharArray)
                     End If
+#End Region
+                    ' Done figuring out the desktop entry type.
+                End If
 
-                    Process.Start(execProgram)
+                ' Expand environment variables.
+                cleanedExecKey = expandEnvVars(cleanedExecKey)
+                If My.Settings.ShowExecKeyBeforeLaunch = True Then
+                    MessageBox.Show(cleanedExecKey)
+                End If
+                ' TODO: Switch the urlList to WSL paths if
+                ' the .desktop file wants it.
+                urlList = expandEnvVars(urlList)
 
-                Catch ex As System.ComponentModel.Win32Exception
-                    ' Show a messagebox for explanation.
-                    ' If it's a Link, show the URL key.
-                    If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" Then
-                        MessageBox.Show("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
+                ' Now, see if urlList has anything in it, and if it does,
+                ' send that URL as an argument to the application.
+                Dim execProgram As New ProcessStartInfo
+                execProgram.FileName = cleanedExecKey
+                execProgram.Arguments = urlList.Trim
+                ' Don't add space if there are no args.
+                If execProgram.Arguments.Length > 0 Then
+                    Console.WriteLine("Launching " & execProgram.FileName & " " & execProgram.Arguments & "...")
+                Else
+                    Console.WriteLine("Launching " & execProgram.FileName & "...")
+                End If
+
+                Process.Start(execProgram)
+
+            Catch ex As System.ComponentModel.Win32Exception
+                ' Show a messagebox for explanation.
+                ' If it's a Link, show the URL key.
+                If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" Then
+                    MessageBox.Show("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
                             vbCrLf &
                             "URL key value: " & desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL"), System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName)
-                    Else
-                        ' If it's an application, show the Exec key.
-                        MessageBox.Show("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
+                Else
+                    ' If it's an application, show the Exec key.
+                    MessageBox.Show("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
                                                     vbCrLf &
                                                     "Exec key value: " & desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Exec"), System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName)
-                    End If
+                End If
 
 
-                End Try
+            End Try
 
-            Else
-                ' If it's not a valid Freedesktop.org .desktop file, tell the user.
-                MessageBox.Show("This .desktop file doesn't have a valid Desktop Entry header/section, which is required by the Freedesktop.org Desktop Entry spec.",
+        Else
+            ' If it's not a valid Freedesktop.org .desktop file, tell the user.
+            MessageBox.Show("This .desktop file doesn't have a valid Desktop Entry header/section, which is required by the Freedesktop.org Desktop Entry spec.",
                                 "Launch .desktop file")
             End If
     End Function

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -399,20 +399,20 @@ Public Class desktopEntryStuff
                             '    ' to be Linux-style if the desktop entry file wanted it or not.
                             '    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
                         Else
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", String.Empty)
-                            End If
-                            ' Clean up unused flags.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                            Else
-                                ' If the user cancels, just remove the %f.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
-                                ' Clean up unused flags.
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                            End If
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", String.Empty)
+                        End If
+                        ' Clean up unused flags.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                    Else
+                        ' If the user cancels, just remove the %f.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                        ' Clean up unused flags.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                    End If
 
                         ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
                             ' If there's a %F, allow for choosing multiple files.

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -370,97 +370,109 @@ Public Class desktopEntryStuff
 
                     ElseIf regexCheckFlags(cleanedExecKey, "%f") Then
                         ' If there's a %f, allow for choosing one file.
-                        Dim openFileDialog As New OpenFileDialog()
-                        openFileDialog.Filter = "All files (*.*)|*.*"
-                        openFileDialog.RestoreDirectory = True
+                        ' For now this is commented out because there
+                        ' needs to be a way to get a file from the calling
+                        ' app, rather than in this library.
+                        If autoCleanMissingFilePathsAndUrls = False Then
+                            'Dim openFileDialog As New OpenFileDialog()
+                            'openFileDialog.Filter = "All files (*.*)|*.*"
+                            'openFileDialog.RestoreDirectory = True
 
-                        If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
-                            ' If the user chooses a file, replace %f with the filename and path.
-                            Dim fileName As String = openFileDialog.FileName
-                            Dim quoteForFilePaths As String = Chr(34)
-                            ' If the .desktop file requests it, switch the paths to be Linux-style.
-                            If getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+                            'If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
+                            '    ' If the user chooses a file, replace %f with the filename and path.
+                            '    Dim fileName As String = openFileDialog.FileName
+                            '    Dim quoteForFilePaths As String = (CChar(""""))
+                            '    ' If the .desktop file requests it, switch the paths to be Linux-style.
+                            '    If getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
 
-                                ' Convert the filename/file path to what WSL distros expect.
-                                fileName = convertPathsStyleToWSL(fileName)
-                                ' Set quote used in file paths to a single quote.
-                                quoteForFilePaths = "'"
+                            '        ' Convert the filename/file path to what WSL distros expect.
+                            '        fileName = convertPathsStyleToWSL(fileName)
+                            '        ' Set quote used in file paths to a single quote.
+                            '        quoteForFilePaths = "'"
 
+                            '    Else
+                            '        ' Remove the double-quotes on the end of the filename.
+                            '        fileName = fileName.TrimEnd(CChar(""""))
+                            '    End If
+
+                            '    ' Update cleanedExecKey with the fileName, which may or may not have been modified
+                            '    ' to be Linux-style if the desktop entry file wanted it or not.
+                            '    cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
+                        Else
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", String.Empty)
+                            End If
+                            ' Clean up unused flags.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
                             Else
-                                ' Remove the double-quotes on the end of the filename.
-                                fileName = fileName.TrimEnd(Chr(34))
+                                ' If the user cancels, just remove the %f.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
                             End If
 
-                            ' Update cleanedExecKey with the fileName, which may or may not have been modified
-                            ' to be Linux-style if the desktop entry file wanted it or not.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
-                            ' Clean up unused flags.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                        Else
-                            ' If the user cancels, just remove the %f.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
-                            ' Clean up unused flags.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                        End If
+                        ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
+                            ' If there's a %F, allow for choosing multiple files.
+                            If autoCleanMissingFilePathsAndUrls = False Then
+                            ' This needs to be set up in a way that'll allow the calling app to send
+                            ' over the list of files. Not sure how to do this at the moment, so it's
+                            ' commented out for now.
 
-                    ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
-                        ' If there's a %F, allow for choosing multiple files.
-                        Dim openFileDialog As New OpenFileDialog()
-                        openFileDialog.Filter = "All files (*.*)|*.*"
-                        openFileDialog.RestoreDirectory = True
-                        openFileDialog.Multiselect = True
+                            '    Dim openFileDialog As New OpenFileDialog()
+                            'openFileDialog.Filter = "All files (*.*)|*.*"
+                            'openFileDialog.RestoreDirectory = True
+                            'openFileDialog.Multiselect = True
 
-                        If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
-                            ' If the user chooses files, replace %F with the filename and paths.
-                            ' Get a file name list array as a string from the open file dialog.
-                            Dim fileNameList As String() = openFileDialog.FileNames
+                            'If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
+                            '    ' If the user chooses files, replace %F with the filename and paths.
+                            '    ' Get a file name list array as a string from the open file dialog.
+                            '    Dim fileNameList As String() = openFileDialog.FileNames
 
-                            ' Define a path list to store the filenames into.
-                            Dim entirePathList As New List(Of String)
-                            ' Define a quote character for putting at the beginning
-                            ' and end of filenames. This can be changed if necessary,
-                            ' such as if a desktop entry file wants to use a Linux-style
-                            ' path instead of Windows-style.
-                            Dim quoteForFilePaths As String = Chr(34)
-                            For Each fileName As String In fileNameList
-                                ' If the .desktop file requests it, switch the paths to be Linux-style.
-                                If getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+                            '    ' Define a path list to store the filenames into.
+                            '    Dim entirePathList As New List(Of String)
+                            '    ' Define a quote character for putting at the beginning
+                            '    ' and end of filenames. This can be changed if necessary,
+                            '    ' such as if a desktop entry file wants to use a Linux-style
+                            '    ' path instead of Windows-style.
+                            '    Dim quoteForFilePaths As String = Chr(34)
+                            '    For Each fileName As String In fileNameList
+                            '        ' If the .desktop file requests it, switch the paths to be Linux-style.
+                            '        If getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
 
-                                    ' Set quote used in file paths to a single quote.
-                                    quoteForFilePaths = "'"
-                                    ' Add the newly-modified filename to the path list.
+                            '            ' Set quote used in file paths to a single quote.
+                            '            quoteForFilePaths = "'"
+                            '            ' Add the newly-modified filename to the path list.
 
-                                    ' Put a question mark at the end of the filename
-                                    ' for later use when joining the string.
-                                    ' It may be a good idea to allow this to be a configurable option
-                                    ' in case the user runs into issues on other filesystems that allow
-                                    ' the question mark to be in a filename.
+                            '            ' Put a question mark at the end of the filename
+                            '            ' for later use when joining the string.
+                            '            ' It may be a good idea to allow this to be a configurable option
+                            '            ' in case the user runs into issues on other filesystems that allow
+                            '            ' the question mark to be in a filename.
 
-                                    ' Convert the filename/file path to what WSL distros expect.
-                                    entirePathList.Add(quoteForFilePaths & convertPathsStyleToWSL(fileName) & quoteForFilePaths & " ?")
+                            '            ' Convert the filename/file path to what WSL distros expect.
+                            '            entirePathList.Add(quoteForFilePaths & convertPathsStyleToWSL(fileName) & quoteForFilePaths & " ?")
 
-                                Else
-                                    ' Remove the double-quotes on the end of the filename.
-                                    fileName = fileName.TrimEnd(Chr(34))
-                                    ' Add the filename to the path list.
+                            '        Else
+                            '            ' Remove the double-quotes on the end of the filename.
+                            '            fileName = fileName.TrimEnd(Chr(34))
+                            '            ' Add the filename to the path list.
 
-                                    ' Put a question mark at the end of the filename
-                                    ' for later use when joining the string.
-                                    ' It may be a good idea to allow this to be a configurable option
-                                    ' in case the user runs into issues on other filesystems that allow
-                                    ' the question mark to be in a filename.
-                                    entirePathList.Add(quoteForFilePaths & fileName & quoteForFilePaths & " ?")
-                                End If
+                            '            ' Put a question mark at the end of the filename
+                            '            ' for later use when joining the string.
+                            '            ' It may be a good idea to allow this to be a configurable option
+                            '            ' in case the user runs into issues on other filesystems that allow
+                            '            ' the question mark to be in a filename.
+                            '            entirePathList.Add(quoteForFilePaths & fileName & quoteForFilePaths & " ?")
+                            '        End If
 
-                            Next
-                            ' Make a new string that joins the file name list into one string.
-                            Dim filesList As String = String.Join("?", entirePathList)
-                            ' Replace the joiner character with an empty string.
-                            filesList = filesList.Replace("?", "")
+                            '    Next
+                            '    ' Make a new string that joins the file name list into one string.
+                            '    Dim filesList As String = String.Join("?", entirePathList)
+                            '    ' Replace the joiner character with an empty string.
+                            '    filesList = filesList.Replace("?", "")
 
                             ' Expand %F with the new file list, and add double-quotes on each side
                             ' of the file list after putting in a space to separate it from the rest

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -296,23 +296,23 @@ Public Class desktopEntryStuff
                 Dim urlList As String = ""
 
                 ' Check to see if the desktop entry is a link or an application.
-                If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
-                       desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL") IsNot Nothing Then
+                If desktopEntryStuff.getInfo(inputFile, "Type") = "Link" AndAlso
+                       desktopEntryStuff.getInfo(inputFile, "URL") IsNot Nothing Then
                     ' If it's a link, grab the URL key if it exists.
-                    cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL")
+                    cleanedExecKey = desktopEntryStuff.getInfo(inputFile, "URL")
 
-                ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
-                       desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL") Is Nothing Then
+                ElseIf desktopEntryStuff.getInfo(inputFile, "Type") = "Link" AndAlso
+                       desktopEntryStuff.getInfo(inputFile, "URL") Is Nothing Then
                     ' If the URL key doesn't exist, allow for URL entry.
                     cleanedExecKey = InputBox("Please type or paste a URL:", "URL key missing")
 
-                ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Directory" Then
+                ElseIf desktopEntryStuff.getInfo(inputFile, "Type") = "Directory" Then
                     ' Directories aren't supported in this program.
                     MessageBox.Show("Directory entries aren't supported by LaunchDotDesktop.", "Unsupported entry type")
                     Exit Try
                 Else
                     ' Otherwise, assume it's an application.
-                    cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Exec")
+                    cleanedExecKey = desktopEntryStuff.getInfo(inputFile, "Exec")
 #Region "Clean up Exec key if needed, and allow for choosing files and URLs."
 
                     ' %d is deprecated.
@@ -360,7 +360,7 @@ Public Class desktopEntryStuff
                             Dim fileName As String = openFileDialog.FileName
                             Dim quoteForFilePaths As String = Chr(34)
                             ' If the .desktop file requests it, switch the paths to be Linux-style.
-                            If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+                            If desktopEntryStuff.getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
 
                                 ' Convert the filename/file path to what WSL distros expect.
                                 fileName = convertPathsStyleToWSL(fileName)
@@ -409,7 +409,7 @@ Public Class desktopEntryStuff
                             Dim quoteForFilePaths As String = Chr(34)
                             For Each fileName As String In fileNameList
                                 ' If the .desktop file requests it, switch the paths to be Linux-style.
-                                If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+                                If desktopEntryStuff.getInfo(inputFile, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
 
                                     ' Set quote used in file paths to a single quote.
                                     quoteForFilePaths = "'"
@@ -523,15 +523,15 @@ Public Class desktopEntryStuff
             Catch ex As System.ComponentModel.Win32Exception
                 ' Show a messagebox for explanation.
                 ' If it's a Link, show the URL key.
-                If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" Then
+                If desktopEntryStuff.getInfo(inputFile, "Type") = "Link" Then
                     MessageBox.Show("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
                             vbCrLf &
-                            "URL key value: " & desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL"), System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName)
+                            "URL key value: " & desktopEntryStuff.getInfo(inputFile, "URL"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
                 Else
                     ' If it's an application, show the Exec key.
                     MessageBox.Show("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
                                                     vbCrLf &
-                                                    "Exec key value: " & desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Exec"), System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName)
+                                                    "Exec key value: " & desktopEntryStuff.getInfo(inputFile, "Exec"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
                 End If
 
 

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -407,8 +407,8 @@ Public Class desktopEntryStuff
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
 
                         ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
-                            ' If there's a %F, allow for choosing multiple files.
-                            If autoCleanMissingFilePathsAndUrls = False Then
+                        ' If there's a %F, allow for choosing multiple files.
+                        If autoCleanMissingFilePathsAndUrls = False Then
                             ' This needs to be set up in a way that'll allow the calling app to send
                             ' over the list of files. Not sure how to do this at the moment, so it's
                             ' commented out for now.
@@ -469,19 +469,14 @@ Public Class desktopEntryStuff
                             ' Expand %F with the new file list, and add double-quotes on each side
                             ' of the file list after putting in a space to separate it from the rest
                             ' of the command.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList.TrimEnd)
-                            ' Clean up unused flags.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                            'cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList.TrimEnd)
                         Else
-                            ' If the user cancels, just remove the %F.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                            ' Clean up unused flags.
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", String.Empty)
                         End If
+                        ' Clean up unused flags.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
                     End If
 
                     ' Split Exec key's program from the arguments, if necessary.

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -531,7 +531,10 @@ Public Class desktopEntryStuff
                 ' the .desktop file wants it.
                 urlList = expandEnvVars(urlList)
 
-                ' Return the cleanedExecKey to the program that requested it.
+            ' Return the cleanedExecKey to the program that requested it.
+            Return cleanedExecKey
+
+
             ' The launcher code is commented out because it may be useful.
 
 

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -487,11 +487,11 @@ Public Class desktopEntryStuff
                     'cleanedExecKey = LTrim(cleanedExecKey)
 
                     ' Check for Chr(34), which is the double-quote character.
-                    If cleanedExecKey.StartsWith(Chr(34)) Then
+                    If cleanedExecKey.StartsWith(CChar("""")) Then
                         ' Copy the original cleaned exec key for later use in the arg variable.
                         Dim originalCleanedExecKey As String = cleanedExecKey
                         ' Create a temp key to be used when splitting out the EXE filename.
-                        Dim tempExecKey As String() = cleanedExecKey.Split(Chr(34))
+                        Dim tempExecKey As String() = cleanedExecKey.Split(CChar(""""))
                         ' Trim the exec key out at the second double-quote.
                         cleanedExecKey = tempExecKey(1).Trim
                         ' Assign the arg variable to the copy of the exec key and remove

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -482,7 +482,9 @@ Public Class desktopEntryStuff
                     ' Split Exec key's program from the arguments, if necessary.
                     ' Check to see if it starts with double-quotes.
                     ' Get rid of whitespace on the left side.
-                    cleanedExecKey = LTrim(cleanedExecKey)
+                    ' This needs to be in a .NET 5 library, as .NET Standard 2.0
+                    ' doesn't support it.
+                    'cleanedExecKey = LTrim(cleanedExecKey)
 
                     ' Check for Chr(34), which is the double-quote character.
                     If cleanedExecKey.StartsWith(Chr(34)) Then

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -282,7 +282,8 @@ Public Class desktopEntryStuff
 #Region "Cleaning keys."
     ' This function will clean keys as passed to it.
     ' Some features are only available on Windows, such as the file browser dialog.
-    Public Shared Function cleanExecKey(inputFile As String, Optional autoIgnoreMissingFilePathsAndUrls As Boolean = True) As String
+    Public Shared Function cleanExecKey(inputFile As String, Optional autoIgnoreMissingFilePathsAndUrls As Boolean = True,
+                                        Optional manuallyProvidedUrl As String = Nothing) As String
         ' Before doing anything, make sure this is a valid .desktop file
         ' with the proper Desktop Entry/KDE Desktop Entry header.
         If checkHeader(inputFile) = "Desktop Entry" OrElse checkHeader(inputFile) = "KDE Desktop Entry" Then
@@ -305,12 +306,15 @@ Public Class desktopEntryStuff
                        getInfo(inputFile, "URL") Is Nothing Then
                     ' If the URL key doesn't exist, allow for URL entry.
                     ' We can't exactly do this in the library, so it needs to be passed
-                    ' back to the calling application with it intact if requested.
-                    cleanedExecKey = InputBox("Please type or paste a URL:", "URL key missing")
+                    ' back to the calling application with it intact unless a URL is passed
+                    ' from the calling app.
+                    If autoIgnoreMissingFilePathsAndUrls = False AndAlso manuallyProvidedUrl IsNot Nothing Then
+                        cleanedExecKey = manuallyProvidedUrl
+                    End If
 
                 ElseIf getInfo(inputFile, "Type") = "Directory" Then
                     ' Directories aren't supported in this program.
-                    MessageBox.Show("Directory entries aren't supported by LaunchDotDesktop.", "Unsupported entry type")
+                    Console.WriteLine("Directory entries aren't supported by libdotdesktop-standard.", "Unsupported entry type")
                     Exit Try
                 Else
                     ' Otherwise, assume it's an application.

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -519,9 +519,12 @@ Public Class desktopEntryStuff
 
                 ' Expand environment variables.
                 cleanedExecKey = expandEnvVars(cleanedExecKey)
-                If My.Settings.ShowExecKeyBeforeLaunch = True Then
-                    MessageBox.Show(cleanedExecKey)
-                End If
+                ' Comment out the stuff to determine whether the cleaned exec
+                ' key should be shown before launch as that'll be handled
+                ' by the calling app.
+                'If My.Settings.ShowExecKeyBeforeLaunch = True Then
+                '    MessageBox.Show(cleanedExecKey)
+                'End If
                 ' TODO: Switch the urlList to WSL paths if
                 ' the .desktop file wants it.
                 urlList = expandEnvVars(urlList)

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -282,7 +282,7 @@ Public Class desktopEntryStuff
 #Region "Cleaning keys."
     ' This function will clean keys as passed to it.
     ' Some features are only available on Windows, such as the file browser dialog.
-    Public Shared Function cleanExecKey(inputFile As String, Optional autoIgnoreMissingFilePathsAndUrls As Boolean = True,
+    Public Shared Function cleanExecKey(inputFile As String, Optional autoCleanMissingFilePathsAndUrls As Boolean = True,
                                         Optional manuallyProvidedUrl As String = Nothing) As String
         ' Before doing anything, make sure this is a valid .desktop file
         ' with the proper Desktop Entry/KDE Desktop Entry header.
@@ -308,7 +308,7 @@ Public Class desktopEntryStuff
                     ' We can't exactly do this in the library, so it needs to be passed
                     ' back to the calling application with it intact unless a URL is passed
                     ' from the calling app.
-                    If autoIgnoreMissingFilePathsAndUrls = False AndAlso manuallyProvidedUrl IsNot Nothing Then
+                    If autoCleanMissingFilePathsAndUrls = False AndAlso manuallyProvidedUrl IsNot Nothing Then
                         cleanedExecKey = manuallyProvidedUrl
                     End If
 
@@ -349,9 +349,15 @@ Public Class desktopEntryStuff
 
                     ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
                         ' If there's a %U in the file, open a window to allow for entering URLs.
-                        urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
-                        ' Expand %U to what the user entered.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
+                        If autoCleanMissingFilePathsAndUrls = False AndAlso manuallyProvidedUrl IsNot Nothing Then
+                            urlList = manuallyProvidedUrl
+                            ' Expand %U to what the user entered.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
+                        Else
+                            ' Automatically clean the flag.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", String.Empty)
+                        End If
+
                         ' Clean up unused flags.
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
 

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -337,10 +337,16 @@ Public Class desktopEntryStuff
                     ' Determine if the application allows for entering a URL,
                     ' and provide a space to type it in.
                     If regexCheckFlags(cleanedExecKey, "%u") Then
-                        ' If there's a %u in the file, open a window to ask for a URL.
-                        urlList = InputBox("Please type or paste a URL:", "Single URL input")
-                        ' Expand %u to what the user entered.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
+                        ' If there's a %u in the file, either remove or expand the flag
+                        ' based on the calling app.
+                        If autoCleanMissingFilePathsAndUrls = False AndAlso manuallyProvidedUrl IsNot Nothing Then
+                            urlList = manuallyProvidedUrl
+                            ' Expand %u to what the user entered.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
+                        Else
+                            ' Automatically clean the flag.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", String.Empty)
+                        End If
                         ' Clean up unused flags.
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
@@ -348,7 +354,8 @@ Public Class desktopEntryStuff
 
 
                     ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
-                        ' If there's a %U in the file, open a window to allow for entering URLs.
+                        ' If there's a %U in the file, either remove or expand the flag
+                        ' based on the calling app.
                         If autoCleanMissingFilePathsAndUrls = False AndAlso manuallyProvidedUrl IsNot Nothing Then
                             urlList = manuallyProvidedUrl
                             ' Expand %U to what the user entered.

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -282,7 +282,7 @@ Public Class desktopEntryStuff
 #Region "Cleaning keys."
     ' This function will clean keys as passed to it.
     ' Some features are only available on Windows, such as the file browser dialog.
-    Public Shared Function cleanExecKey(inputFile As String) As String
+    Public Shared Function cleanExecKey(inputFile As String, Optional autoIgnoreMissingFilePathsAndUrls As Boolean = True) As String
         ' Before doing anything, make sure this is a valid .desktop file
         ' with the proper Desktop Entry/KDE Desktop Entry header.
         If checkHeader(inputFile) = "Desktop Entry" OrElse checkHeader(inputFile) = "KDE Desktop Entry" Then
@@ -304,6 +304,8 @@ Public Class desktopEntryStuff
                 ElseIf getInfo(inputFile, "Type") = "Link" AndAlso
                        getInfo(inputFile, "URL") Is Nothing Then
                     ' If the URL key doesn't exist, allow for URL entry.
+                    ' We can't exactly do this in the library, so it needs to be passed
+                    ' back to the calling application with it intact if requested.
                     cleanedExecKey = InputBox("Please type or paste a URL:", "URL key missing")
 
                 ElseIf getInfo(inputFile, "Type") = "Directory" Then

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -283,7 +283,274 @@ Public Class desktopEntryStuff
     ' This function will clean keys as passed to it.
     ' Some features are only available on Windows, such as the file browser dialog.
     Public Shared Function cleanKey(inputFile As String) As String
+        ' Before doing anything, make sure this is a valid .desktop file
+        ' with the proper Desktop Entry/KDE Desktop Entry header.
+        If desktopEntryStuff.checkHeader(My.Application.CommandLineArgs(0).ToString) = "Desktop Entry" Or
+                desktopEntryStuff.checkHeader(My.Application.CommandLineArgs(0).ToString) = "KDE Desktop Entry" Then
 
+                ' First, update titlebar and output the file path.
+                Console.WriteLine()
+                Console.WriteLine("Input file: " & My.Application.CommandLineArgs(0).ToString)
+                Console.Title = System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName
+
+                ' Second, update the console after replacing Lf with CrLf.
+                Console.WriteLine(System.IO.File.ReadAllText(My.Application.CommandLineArgs(0).ToString).Replace(vbLf, vbCrLf))
+
+                ' Now, pass along the file to the interpretation code in libdotdesktop.
+                ' Catch NullReferenceExceptions, just in case there are issues in the file.
+                Try
+                    ' Exec key.
+                    Dim cleanedExecKey As String
+                    ' URL list for apps that allow for URLs to be passed to them.
+                    Dim urlList As String = ""
+
+                    ' Check to see if the desktop entry is a link or an application.
+                    If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
+                       desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL") IsNot Nothing Then
+                        ' If it's a link, grab the URL key if it exists.
+                        cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL")
+
+                    ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" AndAlso
+                       desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL") Is Nothing Then
+                        ' If the URL key doesn't exist, allow for URL entry.
+                        cleanedExecKey = InputBox("Please type or paste a URL:", "URL key missing")
+
+                    ElseIf desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Directory" Then
+                        ' Directories aren't supported in this program.
+                        MessageBox.Show("Directory entries aren't supported by LaunchDotDesktop.", "Unsupported entry type")
+                        Exit Try
+                    Else
+                        ' Otherwise, assume it's an application.
+                        cleanedExecKey = desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Exec")
+#Region "Clean up Exec key if needed, and allow for choosing files and URLs."
+
+                        ' %d is deprecated.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%d", "")
+                        ' %D is deprecated.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%D", "")
+                        ' %n is deprecated.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%n", "")
+                        ' %N is deprecated.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%N", "")
+                        ' %v is deprecated.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%v", "")
+                        ' %m is deprecated.
+                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%m", "")
+
+                        ' Determine if the application allows for entering a URL,
+                        ' and provide a space to type it in.
+                        If regexCheckFlags(cleanedExecKey, "%u") Then
+                            ' If there's a %u in the file, open a window to ask for a URL.
+                            urlList = InputBox("Please type or paste a URL:", "Single URL input")
+                            ' Expand %u to what the user entered.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", " " & urlList)
+                            ' Clean up unused flags.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+
+
+                        ElseIf regexCheckFlags(cleanedExecKey, "%U") Then
+                            ' If there's a %U in the file, open a window to allow for entering URLs.
+                            urlList = InputBox("Please type or paste a list of URLs separated by a space:", "Multiple URL input")
+                            ' Expand %U to what the user entered.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", " " & urlList)
+                            ' Clean up unused flags.
+                            cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+
+                        ElseIf regexCheckFlags(cleanedExecKey, "%f") Then
+                            ' If there's a %f, allow for choosing one file.
+                            Dim openFileDialog As New OpenFileDialog()
+                            openFileDialog.Filter = "All files (*.*)|*.*"
+                            openFileDialog.RestoreDirectory = True
+
+                            If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
+                                ' If the user chooses a file, replace %f with the filename and path.
+                                Dim fileName As String = openFileDialog.FileName
+                                Dim quoteForFilePaths As String = Chr(34)
+                                ' If the .desktop file requests it, switch the paths to be Linux-style.
+                                If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+
+                                    ' Convert the filename/file path to what WSL distros expect.
+                                    fileName = convertPathsStyleToWSL(fileName)
+                                    ' Set quote used in file paths to a single quote.
+                                    quoteForFilePaths = "'"
+
+                                Else
+                                    ' Remove the double-quotes on the end of the filename.
+                                    fileName = fileName.TrimEnd(Chr(34))
+                                End If
+
+                                ' Update cleanedExecKey with the fileName, which may or may not have been modified
+                                ' to be Linux-style if the desktop entry file wanted it or not.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", " " & quoteForFilePaths & fileName & quoteForFilePaths)
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                            Else
+                                ' If the user cancels, just remove the %f.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                            End If
+
+                        ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
+                            ' If there's a %F, allow for choosing multiple files.
+                            Dim openFileDialog As New OpenFileDialog()
+                            openFileDialog.Filter = "All files (*.*)|*.*"
+                            openFileDialog.RestoreDirectory = True
+                            openFileDialog.Multiselect = True
+
+                            If openFileDialog.ShowDialog() = System.Windows.Forms.DialogResult.OK Then
+                                ' If the user chooses files, replace %F with the filename and paths.
+                                ' Get a file name list array as a string from the open file dialog.
+                                Dim fileNameList As String() = openFileDialog.FileNames
+
+                                ' Define a path list to store the filenames into.
+                                Dim entirePathList As New List(Of String)
+                                ' Define a quote character for putting at the beginning
+                                ' and end of filenames. This can be changed if necessary,
+                                ' such as if a desktop entry file wants to use a Linux-style
+                                ' path instead of Windows-style.
+                                Dim quoteForFilePaths As String = Chr(34)
+                                For Each fileName As String In fileNameList
+                                    ' If the .desktop file requests it, switch the paths to be Linux-style.
+                                    If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "X-DotDesktop4Win-UseWSLFilePaths") = "true" Then
+
+                                        ' Set quote used in file paths to a single quote.
+                                        quoteForFilePaths = "'"
+                                        ' Add the newly-modified filename to the path list.
+
+                                        ' Put a question mark at the end of the filename
+                                        ' for later use when joining the string.
+                                        ' It may be a good idea to allow this to be a configurable option
+                                        ' in case the user runs into issues on other filesystems that allow
+                                        ' the question mark to be in a filename.
+
+                                        ' Convert the filename/file path to what WSL distros expect.
+                                        entirePathList.Add(quoteForFilePaths & convertPathsStyleToWSL(fileName) & quoteForFilePaths & " ?")
+
+                                    Else
+                                        ' Remove the double-quotes on the end of the filename.
+                                        fileName = fileName.TrimEnd(Chr(34))
+                                        ' Add the filename to the path list.
+
+                                        ' Put a question mark at the end of the filename
+                                        ' for later use when joining the string.
+                                        ' It may be a good idea to allow this to be a configurable option
+                                        ' in case the user runs into issues on other filesystems that allow
+                                        ' the question mark to be in a filename.
+                                        entirePathList.Add(quoteForFilePaths & fileName & quoteForFilePaths & " ?")
+                                    End If
+
+                                Next
+                                ' Make a new string that joins the file name list into one string.
+                                Dim filesList As String = String.Join("?", entirePathList)
+                                ' Replace the joiner character with an empty string.
+                                filesList = filesList.Replace("?", "")
+
+                                ' Expand %F with the new file list, and add double-quotes on each side
+                                ' of the file list after putting in a space to separate it from the rest
+                                ' of the command.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", " " & filesList.TrimEnd)
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                            Else
+                                ' If the user cancels, just remove the %F.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+                                ' Clean up unused flags.
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+                                cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+                            End If
+                        End If
+
+                        ' Split Exec key's program from the arguments, if necessary.
+                        ' Check to see if it starts with double-quotes.
+                        ' Get rid of whitespace on the left side.
+                        cleanedExecKey = LTrim(cleanedExecKey)
+
+                        ' Check for Chr(34), which is the double-quote character.
+                        If cleanedExecKey.StartsWith(Chr(34)) Then
+                            ' Copy the original cleaned exec key for later use in the arg variable.
+                            Dim originalCleanedExecKey As String = cleanedExecKey
+                            ' Create a temp key to be used when splitting out the EXE filename.
+                            Dim tempExecKey As String() = cleanedExecKey.Split(Chr(34))
+                            ' Trim the exec key out at the second double-quote.
+                            cleanedExecKey = tempExecKey(1).Trim
+                            ' Assign the arg variable to the copy of the exec key and remove
+                            ' the double-quotes before and after and the new exec key 
+                            ' from the beginning of the URL list/arg variable.
+                            urlList = originalCleanedExecKey.Remove(0, cleanedExecKey.Length + 2)
+                        Else
+                            ' If there's no double-quotes, assume it's something like
+                            ' firefox.exe or another string without spaces.
+                            ' We'll need to split this one at the first space character.
+
+                            ' Copy the original cleaned exec key for later use in the arg variable.
+                            Dim originalCleanedExecKey As String = cleanedExecKey
+                            ' Create a temp key to be used when splitting out the EXE filename.
+                            Dim tempExecKey As String() = cleanedExecKey.Split(" "c)
+                            ' Trim the exec key out at the first space.
+                            cleanedExecKey = tempExecKey(0).Trim
+                            ' Assign the arg variable to the copy of the exec key and trim
+                            ' out the exec key.
+                            urlList = originalCleanedExecKey.TrimStart(cleanedExecKey.ToCharArray)
+                        End If
+#End Region
+                        ' Done figuring out the desktop entry type.
+                    End If
+
+                    ' Expand environment variables.
+                    cleanedExecKey = expandEnvVars(cleanedExecKey)
+                    If My.Settings.ShowExecKeyBeforeLaunch = True Then
+                        MessageBox.Show(cleanedExecKey)
+                    End If
+                    ' TODO: Switch the urlList to WSL paths if
+                    ' the .desktop file wants it.
+                    urlList = expandEnvVars(urlList)
+
+                    ' Now, see if urlList has anything in it, and if it does,
+                    ' send that URL as an argument to the application.
+                    Dim execProgram As New ProcessStartInfo
+                    execProgram.FileName = cleanedExecKey
+                    execProgram.Arguments = urlList.Trim
+                    ' Don't add space if there are no args.
+                    If execProgram.Arguments.Length > 0 Then
+                        Console.WriteLine("Launching " & execProgram.FileName & " " & execProgram.Arguments & "...")
+                    Else
+                        Console.WriteLine("Launching " & execProgram.FileName & "...")
+                    End If
+
+                    Process.Start(execProgram)
+
+                Catch ex As System.ComponentModel.Win32Exception
+                    ' Show a messagebox for explanation.
+                    ' If it's a Link, show the URL key.
+                    If desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Type") = "Link" Then
+                        MessageBox.Show("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
+                            vbCrLf &
+                            "URL key value: " & desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "URL"), System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName)
+                    Else
+                        ' If it's an application, show the Exec key.
+                        MessageBox.Show("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
+                                                    vbCrLf &
+                                                    "Exec key value: " & desktopEntryStuff.getInfo(My.Application.CommandLineArgs(0).ToString, "Exec"), System.IO.Path.GetFileName(My.Application.CommandLineArgs(0).ToString) & " - " & Application.ProductName)
+                    End If
+
+
+                End Try
+
+            Else
+                ' If it's not a valid Freedesktop.org .desktop file, tell the user.
+                MessageBox.Show("This .desktop file doesn't have a valid Desktop Entry header/section, which is required by the Freedesktop.org Desktop Entry spec.",
+                                "Launch .desktop file")
+            End If
     End Function
 #End Region
 

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -296,23 +296,23 @@ Public Class desktopEntryStuff
                 Dim urlList As String = ""
 
                 ' Check to see if the desktop entry is a link or an application.
-                If desktopEntryStuff.getInfo(inputFile, "Type") = "Link" AndAlso
-                       desktopEntryStuff.getInfo(inputFile, "URL") IsNot Nothing Then
+                If getInfo(inputFile, "Type") = "Link" AndAlso
+                       getInfo(inputFile, "URL") IsNot Nothing Then
                     ' If it's a link, grab the URL key if it exists.
-                    cleanedExecKey = desktopEntryStuff.getInfo(inputFile, "URL")
+                    cleanedExecKey = getInfo(inputFile, "URL")
 
-                ElseIf desktopEntryStuff.getInfo(inputFile, "Type") = "Link" AndAlso
-                       desktopEntryStuff.getInfo(inputFile, "URL") Is Nothing Then
+                ElseIf getInfo(inputFile, "Type") = "Link" AndAlso
+                       getInfo(inputFile, "URL") Is Nothing Then
                     ' If the URL key doesn't exist, allow for URL entry.
                     cleanedExecKey = InputBox("Please type or paste a URL:", "URL key missing")
 
-                ElseIf desktopEntryStuff.getInfo(inputFile, "Type") = "Directory" Then
+                ElseIf getInfo(inputFile, "Type") = "Directory" Then
                     ' Directories aren't supported in this program.
                     MessageBox.Show("Directory entries aren't supported by LaunchDotDesktop.", "Unsupported entry type")
                     Exit Try
                 Else
                     ' Otherwise, assume it's an application.
-                    cleanedExecKey = desktopEntryStuff.getInfo(inputFile, "Exec")
+                    cleanedExecKey = getInfo(inputFile, "Exec")
 #Region "Clean up Exec key if needed, and allow for choosing files and URLs."
 
                     ' %d is deprecated.
@@ -523,15 +523,15 @@ Public Class desktopEntryStuff
             Catch ex As System.ComponentModel.Win32Exception
                 ' Show a messagebox for explanation.
                 ' If it's a Link, show the URL key.
-                If desktopEntryStuff.getInfo(inputFile, "Type") = "Link" Then
+                If getInfo(inputFile, "Type") = "Link" Then
                     MessageBox.Show("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
                             vbCrLf &
-                            "URL key value: " & desktopEntryStuff.getInfo(inputFile, "URL"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
+                            "URL key value: " & getInfo(inputFile, "URL"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
                 Else
                     ' If it's an application, show the Exec key.
                     MessageBox.Show("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
                                                     vbCrLf &
-                                                    "Exec key value: " & desktopEntryStuff.getInfo(inputFile, "Exec"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
+                                                    "Exec key value: " & getInfo(inputFile, "Exec"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
                 End If
 
 

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -290,9 +290,11 @@ Public Class desktopEntryStuff
 
             ' Now, clean the exec key.
             ' Catch NullReferenceExceptions, just in case there are issues in the file.
-            Try
-                ' Exec key.
-                Dim cleanedExecKey As String
+            ' The Try/Catch code is commented out for now as I don't know if Win32Exceptions would work
+            ' on Linux.
+            'Try
+            ' Exec key.
+            Dim cleanedExecKey As String
                 ' URL list for apps that allow for URLs to be passed to them.
                 Dim urlList As String = ""
 
@@ -529,7 +531,7 @@ Public Class desktopEntryStuff
                 ' the .desktop file wants it.
                 urlList = expandEnvVars(urlList)
 
-            ' Return the cleanedExecKey to the program that requested it.
+                ' Return the cleanedExecKey to the program that requested it.
             ' The launcher code is commented out because it may be useful.
 
 
@@ -548,22 +550,22 @@ Public Class desktopEntryStuff
 
             '        Process.Start(execProgram)
 
-            '    Catch ex As System.ComponentModel.Win32Exception
-            '        ' Show a messagebox for explanation.
-            '        ' If it's a Link, show the URL key.
-            '        If getInfo(inputFile, "Type") = "Link" Then
-            '            Console.WriteLine("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
-            '                    vbCrLf &
-            '                    "URL key value: " & getInfo(inputFile, "URL"), System.IO.Path.GetFileName(inputFile) & " - libdotdesktop-standard")
-            '        Else
-            '            ' If it's an application, show the Exec key.
-            '            Console.WriteLine("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
-            '                                            vbCrLf &
-            '                                            "Exec key value: " & getInfo(inputFile, "Exec"), System.IO.Path.GetFileName(inputFile) & " - libdotdesktop-standard")
-            '        End If
+            'Catch ex As System.ComponentModel.Win32Exception
+            '    ' Show a messagebox for explanation.
+            '    ' If it's a Link, show the URL key.
+            '    If getInfo(inputFile, "Type") = "Link" Then
+            '        Console.WriteLine("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
+            '                vbCrLf &
+            '                "URL key value: " & getInfo(inputFile, "URL"), System.IO.Path.GetFileName(inputFile) & " - libdotdesktop-standard")
+            '    Else
+            '        ' If it's an application, show the Exec key.
+            '        Console.WriteLine("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
+            '                                        vbCrLf &
+            '                                        "Exec key value: " & getInfo(inputFile, "Exec"), System.IO.Path.GetFileName(inputFile) & " - libdotdesktop-standard")
+            '    End If
 
 
-            '    End Try
+            'End Try
 
             'Else
             '    ' If it's not a valid Freedesktop.org .desktop file, tell the user.

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -529,41 +529,46 @@ Public Class desktopEntryStuff
                 ' the .desktop file wants it.
                 urlList = expandEnvVars(urlList)
 
-                ' Now, see if urlList has anything in it, and if it does,
-                ' send that URL as an argument to the application.
-                Dim execProgram As New ProcessStartInfo
-                execProgram.FileName = cleanedExecKey
-                execProgram.Arguments = urlList.Trim
-                ' Don't add space if there are no args.
-                If execProgram.Arguments.Length > 0 Then
-                    Console.WriteLine("Launching " & execProgram.FileName & " " & execProgram.Arguments & "...")
-                Else
-                    Console.WriteLine("Launching " & execProgram.FileName & "...")
-                End If
-
-                Process.Start(execProgram)
-
-            Catch ex As System.ComponentModel.Win32Exception
-                ' Show a messagebox for explanation.
-                ' If it's a Link, show the URL key.
-                If getInfo(inputFile, "Type") = "Link" Then
-                    MessageBox.Show("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
-                            vbCrLf &
-                            "URL key value: " & getInfo(inputFile, "URL"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
-                Else
-                    ' If it's an application, show the Exec key.
-                    MessageBox.Show("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
-                                                    vbCrLf &
-                                                    "Exec key value: " & getInfo(inputFile, "Exec"), System.IO.Path.GetFileName(inputFile) & " - " & Application.ProductName)
-                End If
+            ' Return the cleanedExecKey to the program that requested it.
+            ' The launcher code is commented out because it may be useful.
 
 
-            End Try
 
-        Else
-            ' If it's not a valid Freedesktop.org .desktop file, tell the user.
-            MessageBox.Show("This .desktop file doesn't have a valid Desktop Entry header/section, which is required by the Freedesktop.org Desktop Entry spec.",
-                                "Launch .desktop file")
+            '        ' Now, see if urlList has anything in it, and if it does,
+            '        ' send that URL as an argument to the application.
+            '        Dim execProgram As New ProcessStartInfo
+            '        execProgram.FileName = cleanedExecKey
+            '        execProgram.Arguments = urlList.Trim
+            '        ' Don't add space if there are no args.
+            '        If execProgram.Arguments.Length > 0 Then
+            '            Console.WriteLine("Launching " & execProgram.FileName & " " & execProgram.Arguments & "...")
+            '        Else
+            '            Console.WriteLine("Launching " & execProgram.FileName & "...")
+            '        End If
+
+            '        Process.Start(execProgram)
+
+            '    Catch ex As System.ComponentModel.Win32Exception
+            '        ' Show a messagebox for explanation.
+            '        ' If it's a Link, show the URL key.
+            '        If getInfo(inputFile, "Type") = "Link" Then
+            '            Console.WriteLine("We couldn't find the address that was listed in the URL key or passed manually. You can check the console output if you want to see what it could be." & vbCrLf &
+            '                    vbCrLf &
+            '                    "URL key value: " & getInfo(inputFile, "URL"), System.IO.Path.GetFileName(inputFile) & " - libdotdesktop-standard")
+            '        Else
+            '            ' If it's an application, show the Exec key.
+            '            Console.WriteLine("Either there are characters where they shouldn't be, or we couldn't find the program specified in the Exec key. You can check the console output if you want to see what it could be." & vbCrLf &
+            '                                            vbCrLf &
+            '                                            "Exec key value: " & getInfo(inputFile, "Exec"), System.IO.Path.GetFileName(inputFile) & " - libdotdesktop-standard")
+            '        End If
+
+
+            '    End Try
+
+            'Else
+            '    ' If it's not a valid Freedesktop.org .desktop file, tell the user.
+            '    Console.WriteLine("This .desktop file doesn't have a valid Desktop Entry header/section, which is required by the Freedesktop.org Desktop Entry spec.",
+            '                        "Launch .desktop file")
         End If
     End Function
 #End Region

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -317,8 +317,8 @@ Public Class desktopEntryStuff
                 ElseIf getInfo(inputFile, "Type") = "Directory" Then
                     ' Directories aren't supported in this program.
                     Console.WriteLine("Directory entries aren't supported by libdotdesktop-standard.", "Unsupported entry type")
-                    Exit Try
-                Else
+                Exit Function
+            Else
                     ' Otherwise, assume it's an application.
                     cleanedExecKey = getInfo(inputFile, "Exec")
 #Region "Clean up Exec key if needed, and allow for choosing files and URLs."

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -405,14 +405,6 @@ Public Class desktopEntryStuff
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
                         cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                    Else
-                        ' If the user cancels, just remove the %f.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
-                        ' Clean up unused flags.
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
-                        cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
-                    End If
 
                         ElseIf regexCheckFlags(cleanedExecKey, "%F") Then
                             ' If there's a %F, allow for choosing multiple files.

--- a/libdotdesktop-standard/libdotdesktop-standard.vb
+++ b/libdotdesktop-standard/libdotdesktop-standard.vb
@@ -551,7 +551,7 @@ Public Class desktopEntryStuff
     End Function
 #End Region
 
-    Private Function convertPathsStyleToWSL(fileName As String) As String
+    Private Shared Function convertPathsStyleToWSL(fileName As String) As String
         ' Convert Windows paths to be usable under WSL.
         If fileName.Substring(1, 2) = ":\" Then
             ' Grab the drive letter and make it lowercase for later use.
@@ -571,7 +571,7 @@ Public Class desktopEntryStuff
         Return fileName
     End Function
 
-    Private Function regexReplaceFlags(input As String, flag As String, desiredReplacement As String, Optional caseSensitive As Boolean = True) As String
+    Private Shared Function regexReplaceFlags(input As String, flag As String, desiredReplacement As String, Optional caseSensitive As Boolean = True) As String
         ' Replaces flags in the style of %u with a string using regex.
         ' First we need to create a regular expression to match what'll
         ' be replaced.
@@ -606,7 +606,7 @@ Public Class desktopEntryStuff
         End If
     End Function
 
-    Private Function regexCheckFlags(input As String, flag As String, Optional caseSensitive As Boolean = True) As Boolean
+    Private Shared Function regexCheckFlags(input As String, flag As String, Optional caseSensitive As Boolean = True) As Boolean
         ' Check to see if the input string contains a flag in the style of %u using regex.
         ' If there's a match, this'll return a Boolean.
         ' \s+ is for whitespace before the flag.
@@ -642,7 +642,7 @@ Public Class desktopEntryStuff
     End Function
 
 
-    Private Function expandEnvVars(execOrArg As String) As String
+    Private Shared Function expandEnvVars(execOrArg As String) As String
         If My.Settings.ShowExecKeyBeforeLaunch = True Then
             MessageBox.Show(execOrArg)
         End If


### PR DESCRIPTION
Keys can now have their flags cleaned in the library to make it easier to launch what's in the Exec key without re-typing code. Currently only some of the functionality of the original code in LaunchDotDesktop has been moved over. Notable missing features in the libdotdesktop-standard implementation include:
- Sending a file or list of files to the app in the Exec key
- Try/Catch block to handle exceptions as I don't know for sure if Win32Exceptions will be usable on Linux, though that'll be un-commented soon.
- `LTrim` being called for the cleaned Exec key. This will require an extra .NET 5 helper library, as .NET Standard doesn't have the required function.

Additional notes:
- Calling apps are required to check if they need to send over a URL or list of URLs before cleaning the key. The `manuallyProvidedUrl` string will be used to fill the URL/URLs in during the cleaning process if `autoCleanMissingFilePathsAndUrls` is set to `False` (this is set to `True` by default).
- Once file paths are supported, calling apps will also have to determine which file path/paths to send over to the program in the Exec key before cleaning, as it'll be automatically filled in much like the URL/URLs part.
- Environment variables are currently only expanded for Windows, though support for Linux environment variables will be added in the future.