### PR TITLE
Use Regex to clean the Exec key in the libdotdesktop Python port.

### DIFF
--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -101,10 +101,16 @@ def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 	# Hold the regex in a string for now:
 	tempRegex = "\s+" + flag + "\b"
 	
-	# Check if the flag ends with a percent sign and change
-	# the regex if necessary so it matches the flag later.
 	if flag.endswith("%"):
+		# Check if the flag ends with a percent sign and change
+		# the regex if necessary so it matches the flag later.
+		# Maybe I should keep the "\s+" part in there.
+		# Noticed that it wasn't in the original code.
 		tempRegex = flag.rstrip("%") + "\b%"
+	
+	if caseSensitive == False:
+		# If case-insensitivity is fine for this
+        # flag, have the regex thing ignore case.
 			
 			
 			

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -111,7 +111,9 @@ def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 	if caseSensitive == False:
 		# If case-insensitivity is fine for this
         # flag, have the regex thing ignore case.
-			
+		regexThing = re.compile(tempRegex, re.IGNORECASE)
+		# Replace the flag.
+		return regexThing.sub(input, desiredReplacement)
 			
 			
 			

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -84,6 +84,8 @@ def getInfo(inputFile, keyToGet, defaultValue, fileName = "", IsCustomKey = Fals
 			
 def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 	# Code for replacing flags using regex.
+	# Python docs page:
+	# https://docs.python.org/3/howto/regex.html
 	# This is used when launching apps to clean their Exec keys.
 	# Ported from the VB.NET version.
 	# Original comment:
@@ -97,7 +99,7 @@ def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 		# The case-sensitive if statement may need to be cleaned up a bit.
 			
 	# Hold the regex in a string for now:
-	
+	tempRegex = "\s+" + flag + "\b"
 			
 			
 			

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -100,6 +100,11 @@ def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 			
 	# Hold the regex in a string for now:
 	tempRegex = "\s+" + flag + "\b"
+	
+	# Check if the flag ends with a percent sign and change
+	# the regex if necessary so it matches the flag later.
+	if flag.endswith("%"):
+		tempRegex = flag.rstrip("%") + "\b%"
 			
 			
 			

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -85,6 +85,15 @@ def getInfo(inputFile, keyToGet, defaultValue, fileName = "", IsCustomKey = Fals
 			
 			
 			
+def cleanExecKey(inputFile)
+	# Clean up the exec key by removing flags.
+	# Currently assuming everything is an app,
+	# but support for links and urls will be added,
+	# as will checking to ensure the file is a valid
+	# .desktop file.
+
+
+
 def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 	# Code for replacing flags using regex.
 	# Python docs page:

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -117,6 +117,10 @@ def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 		regexThing = re.compile(tempRegex, re.IGNORECASE)
 		# Replace the flag.
 		return regexThing.sub(input, desiredReplacement)
-			
+	else:
+		# Otherwise, don't ignore case.
+		regexThing = re.compile(tempRegex)
+		# Now for the replacement.
+		return regexThing.sub(input, desiredReplacement)
 			
 			

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -79,3 +79,16 @@ def getInfo(inputFile, keyToGet, defaultValue, fileName = "", IsCustomKey = Fals
 			return dotDesktopFileReader.get('Desktop Entry', keyToGet)
 		else:
 			return defaultValue
+			
+			
+			
+def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
+	# Code for replacing flags using regex.
+	# This is used when launching apps to clean their Exec keys.
+	# Ported from the VB.NET version.
+			
+			
+			
+			
+			
+			

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -91,6 +91,9 @@ def cleanExecKey(inputFile)
 	# but support for links and urls will be added,
 	# as will checking to ensure the file is a valid
 	# .desktop file.
+	
+	# Load exec key.
+	cleanedExecKey = getInfo(inputFile, "Exec", inputFile, "", True)
 
 
 

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -108,6 +108,12 @@ def cleanExecKey(inputFile)
 	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%v", "")
 	# %m is deprecated.
 	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%m", "")
+	
+	# Clean up other flags that aren't supported by the Python port.
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%u", "")
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
 
 
 

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -86,8 +86,18 @@ def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 	# Code for replacing flags using regex.
 	# This is used when launching apps to clean their Exec keys.
 	# Ported from the VB.NET version.
+	# Original comment:
+		# Replaces flags in the style of %u with a string using regex.
+		# First we need to create a regular expression to match what'll
+		# be replaced.
+		# \s+ is for whitespace before the flag.
+		# \b is for the word border at the end.
+		# This can be used with flags/environment variables
+		# that end with a percent sign.
+		# The case-sensitive if statement may need to be cleaned up a bit.
 			
-			
+	# Hold the regex in a string for now:
+	
 			
 			
 			

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -114,6 +114,11 @@ def cleanExecKey(inputFile)
 	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%U", "")
 	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%f", "")
 	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%F", "")
+	
+	# TODO: Expand environment variables.
+	
+	# Return the cleaned key.
+	return cleanedExecKey
 
 
 

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -94,6 +94,20 @@ def cleanExecKey(inputFile)
 	
 	# Load exec key.
 	cleanedExecKey = getInfo(inputFile, "Exec", inputFile, "", True)
+	
+	# Begin cleaning the key.
+	# %d is deprecated.
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%d", "")
+	# %D is deprecated.
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%D", "")
+	# %n is deprecated.
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%n", "")
+	# %N is deprecated.
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%N", "")
+	# %v is deprecated.
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%v", "")
+	# %m is deprecated.
+	cleanedExecKey = regexReplaceFlags(cleanedExecKey, "%m", "")
 
 
 
@@ -125,7 +139,7 @@ def regexReplaceFlags(input, flag, desiredReplacement, caseSensitive = True):
 	
 	if caseSensitive == False:
 		# If case-insensitivity is fine for this
-        # flag, have the regex thing ignore case.
+		# flag, have the regex thing ignore case.
 		regexThing = re.compile(tempRegex, re.IGNORECASE)
 		# Replace the flag.
 		return regexThing.sub(input, desiredReplacement)

--- a/libdotdesktop_py/desktopEntryStuff.py
+++ b/libdotdesktop_py/desktopEntryStuff.py
@@ -22,7 +22,10 @@
 
 
 
+# configparser is used as the .desktop file reader.
 import configparser
+# Regex.
+import re
 
 def getInfo(inputFile, keyToGet, defaultValue, fileName = "", IsCustomKey = False):
 	# fileName and IsCustomKey are both optional.


### PR DESCRIPTION
Support needs to be added to RetiledStart so it can be tested, but this should work and allow most apps to be run properly. I didn't add support for passing a list of files or URLs to the Exec key, and I still have to allow for expanding environment variables, but it's mostly there. Perhaps it may be useful to pass a URL or file (or a list of either) to the Exec key's app, but it's not a priority. I'll probably add it since it would be useful to implement a share sheet app, among other things like opening a specific Settings page. However, I don't plan to implement it with a dialog like in the .NET version(s).